### PR TITLE
Implement MVP 02 persistence layer

### DIFF
--- a/.agents/project-rules.md
+++ b/.agents/project-rules.md
@@ -23,7 +23,21 @@ docs/
 - Keep frontend state flows explicit and well named.
 - Do not introduce a framework or service unless it directly supports the MVP.
 - Prefer SQLite for the initial database.
-- Design database records with future `user_id` or `workspace_id` support, even if auth ships after the first prototype.
+- Design database records with required owner scoping from the first schema, even if full authentication ships later.
+
+## Documentation Rules
+
+- Keep project documentation available in both English and Japanese.
+- When adding or changing a product, architecture, data model, setup, or security decision, update the English and Japanese versions in the same change.
+- Bilingual documentation may live in the same file as clearly labeled English and Japanese sections, or in paired files with matching names.
+- If implementation choices differ from existing docs, update the docs before or alongside the code change.
+
+## ドキュメントルール
+
+- Project documentation は English と Japanese の両方を用意する。
+- Product、architecture、data model、setup、security に関する決定を追加または変更した場合は、同じ変更内で English と Japanese の両方を更新する。
+- Bilingual documentation は、同じ file 内に English / Japanese section を明示して書いてもよいし、対応する paired files として分けてもよい。
+- 実装方針が既存 docs とずれる場合は、code change の前、または同じ change の中で docs を更新する。
 
 ## Security Rules
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Koma Planner
 
+## English
+
+Koma Planner turns a rough natural-language goal into small actionable todos that can be edited and saved.
+
+## Japanese
+
 自然言語でやりたいことを投げると、AI がいい感じに分割してそのまま TODO になる。
 
 ## App Layout

--- a/apps/api/app/database.py
+++ b/apps/api/app/database.py
@@ -1,0 +1,21 @@
+import os
+from collections.abc import Generator
+
+from sqlmodel import Session, SQLModel, create_engine
+
+from app import models  # noqa: F401
+
+
+DATABASE_URL = os.getenv("KOMA_DATABASE_URL", "sqlite:///./koma-planner.db")
+
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
+
+
+def create_db_and_tables(db_engine=engine) -> None:
+    SQLModel.metadata.create_all(db_engine)
+
+
+def get_session() -> Generator[Session, None, None]:
+    with Session(engine) as session:
+        yield session

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,7 +1,19 @@
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-app = FastAPI(title="Koma Planner API", version="0.1.0")
+from app.database import create_db_and_tables
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    create_db_and_tables()
+    yield
+
+
+app = FastAPI(title="Koma Planner API", version="0.1.0", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -1,0 +1,60 @@
+from datetime import datetime, timezone
+from enum import StrEnum
+
+from sqlmodel import Field, SQLModel
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class ProjectStatus(StrEnum):
+    ACTIVE = "active"
+    ARCHIVED = "archived"
+
+
+class TaskStatus(StrEnum):
+    TODO = "todo"
+    DONE = "done"
+
+
+class BreakdownRunStatus(StrEnum):
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+class Project(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    owner_id: str = Field(index=True, min_length=1)
+    workspace_id: str | None = Field(default=None, index=True)
+    title: str = Field(min_length=1, max_length=200)
+    goal_text: str = Field(min_length=1)
+    status: ProjectStatus = Field(default=ProjectStatus.ACTIVE, index=True)
+    created_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utc_now)
+
+
+class Task(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    project_id: int = Field(foreign_key="project.id", index=True)
+    parent_task_id: int | None = Field(default=None, foreign_key="task.id", index=True)
+    title: str = Field(min_length=1, max_length=200)
+    description: str | None = None
+    acceptance_criteria: str | None = None
+    status: TaskStatus = Field(default=TaskStatus.TODO, index=True)
+    position: int = Field(default=0, index=True)
+    estimate_minutes: int | None = Field(default=None, ge=0)
+    created_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utc_now)
+
+
+class BreakdownRun(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    project_id: int = Field(foreign_key="project.id", index=True)
+    provider: str = Field(min_length=1, max_length=100)
+    model: str = Field(min_length=1, max_length=200)
+    prompt_version: str = Field(min_length=1, max_length=100)
+    input_goal: str = Field(min_length=1)
+    raw_response: str | None = None
+    status: BreakdownRunStatus = Field(default=BreakdownRunStatus.SUCCEEDED, index=True)
+    created_at: datetime = Field(default_factory=utc_now)

--- a/apps/api/app/repositories.py
+++ b/apps/api/app/repositories.py
@@ -1,0 +1,321 @@
+from collections.abc import Sequence
+
+from sqlmodel import Session, col, select
+
+from app.models import BreakdownRun, BreakdownRunStatus, Project, ProjectStatus, Task, TaskStatus, utc_now
+
+
+def create_project(
+    session: Session,
+    *,
+    owner_id: str,
+    title: str,
+    goal_text: str,
+    workspace_id: str | None = None,
+) -> Project:
+    _require_text(owner_id, "owner_id")
+    _require_text(title, "title")
+    _require_text(goal_text, "goal_text")
+    project = Project(
+        owner_id=owner_id,
+        workspace_id=workspace_id,
+        title=title,
+        goal_text=goal_text,
+    )
+    session.add(project)
+    session.commit()
+    session.refresh(project)
+    return project
+
+
+def list_projects(session: Session, *, owner_id: str) -> list[Project]:
+    statement = (
+        select(Project)
+        .where(Project.owner_id == owner_id)
+        .order_by(col(Project.updated_at).desc(), col(Project.id).desc())
+    )
+    return list(session.exec(statement).all())
+
+
+def get_project(session: Session, *, owner_id: str, project_id: int) -> Project | None:
+    statement = select(Project).where(Project.id == project_id, Project.owner_id == owner_id)
+    return session.exec(statement).first()
+
+
+def update_project(
+    session: Session,
+    *,
+    owner_id: str,
+    project_id: int,
+    title: str | None = None,
+    goal_text: str | None = None,
+    status: ProjectStatus | None = None,
+) -> Project | None:
+    project = get_project(session, owner_id=owner_id, project_id=project_id)
+    if project is None:
+        return None
+
+    if title is not None:
+        project.title = title
+    if goal_text is not None:
+        project.goal_text = goal_text
+    if status is not None:
+        project.status = status
+    project.updated_at = utc_now()
+
+    session.add(project)
+    session.commit()
+    session.refresh(project)
+    return project
+
+
+def delete_project(session: Session, *, owner_id: str, project_id: int) -> bool:
+    project = get_project(session, owner_id=owner_id, project_id=project_id)
+    if project is None:
+        return False
+
+    for breakdown_run in list_breakdown_runs(session, owner_id=owner_id, project_id=project_id):
+        session.delete(breakdown_run)
+    for task in _tasks_children_first(list_tasks(session, owner_id=owner_id, project_id=project_id)):
+        session.delete(task)
+    session.delete(project)
+    session.commit()
+    return True
+
+
+def create_task(
+    session: Session,
+    *,
+    owner_id: str,
+    project_id: int,
+    title: str,
+    description: str | None = None,
+    acceptance_criteria: str | None = None,
+    parent_task_id: int | None = None,
+    position: int | None = None,
+    estimate_minutes: int | None = None,
+) -> Task | None:
+    _require_text(title, "title")
+    project = get_project(session, owner_id=owner_id, project_id=project_id)
+    if project is None:
+        return None
+    if parent_task_id is not None:
+        parent_task = _get_task(
+            session,
+            owner_id=owner_id,
+            project_id=project_id,
+            task_id=parent_task_id,
+        )
+        if parent_task is None:
+            return None
+
+    task_position = position if position is not None else _next_task_position(session, project_id)
+    task = Task(
+        project_id=project_id,
+        parent_task_id=parent_task_id,
+        title=title,
+        description=description,
+        acceptance_criteria=acceptance_criteria,
+        position=task_position,
+        estimate_minutes=estimate_minutes,
+    )
+    session.add(task)
+    project.updated_at = utc_now()
+    session.add(project)
+    session.commit()
+    session.refresh(task)
+    return task
+
+
+def list_tasks(session: Session, *, owner_id: str, project_id: int) -> list[Task]:
+    project = get_project(session, owner_id=owner_id, project_id=project_id)
+    if project is None:
+        return []
+
+    statement = (
+        select(Task)
+        .where(Task.project_id == project_id)
+        .order_by(col(Task.position), col(Task.id))
+    )
+    return list(session.exec(statement).all())
+
+
+def update_task(
+    session: Session,
+    *,
+    owner_id: str,
+    project_id: int,
+    task_id: int,
+    title: str | None = None,
+    description: str | None = None,
+    acceptance_criteria: str | None = None,
+    status: TaskStatus | None = None,
+    position: int | None = None,
+    estimate_minutes: int | None = None,
+) -> Task | None:
+    task = _get_task(session, owner_id=owner_id, project_id=project_id, task_id=task_id)
+    if task is None:
+        return None
+
+    if title is not None:
+        task.title = title
+    if description is not None:
+        task.description = description
+    if acceptance_criteria is not None:
+        task.acceptance_criteria = acceptance_criteria
+    if status is not None:
+        task.status = status
+    if position is not None:
+        task.position = position
+    if estimate_minutes is not None:
+        task.estimate_minutes = estimate_minutes
+    task.updated_at = utc_now()
+
+    project = get_project(session, owner_id=owner_id, project_id=project_id)
+    if project is not None:
+        project.updated_at = utc_now()
+        session.add(project)
+
+    session.add(task)
+    session.commit()
+    session.refresh(task)
+    return task
+
+
+def reorder_tasks(
+    session: Session,
+    *,
+    owner_id: str,
+    project_id: int,
+    task_ids: Sequence[int],
+) -> list[Task] | None:
+    tasks = list_tasks(session, owner_id=owner_id, project_id=project_id)
+    task_by_id = {task.id: task for task in tasks}
+    if len(task_ids) != len(set(task_ids)) or set(task_ids) != set(task_by_id):
+        return None
+
+    for position, task_id in enumerate(task_ids):
+        task = task_by_id[task_id]
+        task.position = position
+        task.updated_at = utc_now()
+        session.add(task)
+
+    project = get_project(session, owner_id=owner_id, project_id=project_id)
+    if project is not None:
+        project.updated_at = utc_now()
+        session.add(project)
+
+    session.commit()
+    return list_tasks(session, owner_id=owner_id, project_id=project_id)
+
+
+def delete_task(session: Session, *, owner_id: str, project_id: int, task_id: int) -> bool:
+    tasks = list_tasks(session, owner_id=owner_id, project_id=project_id)
+    task_by_id = {task.id: task for task in tasks}
+    if task_id not in task_by_id:
+        return False
+
+    for task in _tasks_children_first(tasks, root_task_id=task_id):
+        session.delete(task)
+    project = get_project(session, owner_id=owner_id, project_id=project_id)
+    if project is not None:
+        project.updated_at = utc_now()
+        session.add(project)
+    session.commit()
+    return True
+
+
+def create_breakdown_run(
+    session: Session,
+    *,
+    owner_id: str,
+    project_id: int,
+    provider: str,
+    model: str,
+    prompt_version: str,
+    input_goal: str,
+    raw_response: str | None = None,
+    status: BreakdownRunStatus = BreakdownRunStatus.SUCCEEDED,
+) -> BreakdownRun | None:
+    _require_text(provider, "provider")
+    _require_text(model, "model")
+    _require_text(prompt_version, "prompt_version")
+    _require_text(input_goal, "input_goal")
+
+    project = get_project(session, owner_id=owner_id, project_id=project_id)
+    if project is None:
+        return None
+
+    breakdown_run = BreakdownRun(
+        project_id=project_id,
+        provider=provider,
+        model=model,
+        prompt_version=prompt_version,
+        input_goal=input_goal,
+        raw_response=raw_response,
+        status=status,
+    )
+    session.add(breakdown_run)
+    project.updated_at = utc_now()
+    session.add(project)
+    session.commit()
+    session.refresh(breakdown_run)
+    return breakdown_run
+
+
+def list_breakdown_runs(session: Session, *, owner_id: str, project_id: int) -> list[BreakdownRun]:
+    project = get_project(session, owner_id=owner_id, project_id=project_id)
+    if project is None:
+        return []
+
+    statement = (
+        select(BreakdownRun)
+        .where(BreakdownRun.project_id == project_id)
+        .order_by(col(BreakdownRun.created_at).desc(), col(BreakdownRun.id).desc())
+    )
+    return list(session.exec(statement).all())
+
+
+def _get_task(session: Session, *, owner_id: str, project_id: int, task_id: int) -> Task | None:
+    if get_project(session, owner_id=owner_id, project_id=project_id) is None:
+        return None
+
+    statement = select(Task).where(Task.id == task_id, Task.project_id == project_id)
+    return session.exec(statement).first()
+
+
+def _next_task_position(session: Session, project_id: int) -> int:
+    statement = select(Task).where(Task.project_id == project_id)
+    tasks = session.exec(statement).all()
+    if not tasks:
+        return 0
+    return max(task.position for task in tasks) + 1
+
+
+def _require_text(value: str, field_name: str) -> None:
+    if not value.strip():
+        raise ValueError(f"{field_name} is required")
+
+
+def _tasks_children_first(tasks: Sequence[Task], root_task_id: int | None = None) -> list[Task]:
+    children_by_parent: dict[int | None, list[Task]] = {}
+    task_by_id = {task.id: task for task in tasks}
+    for task in tasks:
+        children_by_parent.setdefault(task.parent_task_id, []).append(task)
+
+    def visit(task: Task) -> list[Task]:
+        ordered: list[Task] = []
+        for child in children_by_parent.get(task.id, []):
+            ordered.extend(visit(child))
+        ordered.append(task)
+        return ordered
+
+    if root_task_id is not None:
+        root_task = task_by_id.get(root_task_id)
+        return visit(root_task) if root_task is not None else []
+
+    ordered_tasks: list[Task] = []
+    for task in tasks:
+        if task.parent_task_id not in task_by_id:
+            ordered_tasks.extend(visit(task))
+    return ordered_tasks

--- a/apps/api/tests/test_persistence.py
+++ b/apps/api/tests/test_persistence.py
@@ -1,0 +1,285 @@
+from collections.abc import Iterator
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+
+from app.database import create_db_and_tables
+from app.models import TaskStatus
+from app.repositories import (
+    create_breakdown_run,
+    create_project,
+    create_task,
+    delete_project,
+    delete_task,
+    get_project,
+    list_breakdown_runs,
+    list_projects,
+    list_tasks,
+    reorder_tasks,
+    update_project,
+    update_task,
+)
+
+
+@pytest.fixture
+def session() -> Iterator[Session]:
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    create_db_and_tables(engine)
+    with Session(engine) as session:
+        yield session
+    SQLModel.metadata.drop_all(engine)
+
+
+def test_project_requires_owner_id(session: Session) -> None:
+    with pytest.raises(ValueError):
+        create_project(
+            session,
+            owner_id="",
+            title="Plan launch",
+            goal_text="Launch a small service",
+        )
+
+
+def test_project_crud_is_scoped_by_owner(session: Session) -> None:
+    project = create_project(
+        session,
+        owner_id="user-a",
+        title="Write docs",
+        goal_text="Document the data model",
+    )
+
+    assert project.id is not None
+    assert get_project(session, owner_id="user-a", project_id=project.id) == project
+    assert get_project(session, owner_id="user-b", project_id=project.id) is None
+    assert list_projects(session, owner_id="user-a") == [project]
+    assert list_projects(session, owner_id="user-b") == []
+
+    updated = update_project(
+        session,
+        owner_id="user-a",
+        project_id=project.id,
+        title="Write bilingual docs",
+    )
+
+    assert updated is not None
+    assert updated.title == "Write bilingual docs"
+    assert delete_project(session, owner_id="user-b", project_id=project.id) is False
+    assert delete_project(session, owner_id="user-a", project_id=project.id) is True
+    assert get_project(session, owner_id="user-a", project_id=project.id) is None
+
+
+def test_task_crud_and_reorder(session: Session) -> None:
+    project = create_project(
+        session,
+        owner_id="user-a",
+        title="Build MVP",
+        goal_text="Finish the first persistence layer",
+    )
+    assert project.id is not None
+
+    first = create_task(session, owner_id="user-a", project_id=project.id, title="Create models")
+    second = create_task(session, owner_id="user-a", project_id=project.id, title="Write tests")
+
+    assert first is not None
+    assert second is not None
+    assert first.id is not None
+    assert second.id is not None
+    assert [task.title for task in list_tasks(session, owner_id="user-a", project_id=project.id)] == [
+        "Create models",
+        "Write tests",
+    ]
+    assert list_tasks(session, owner_id="user-b", project_id=project.id) == []
+
+    completed = update_task(
+        session,
+        owner_id="user-a",
+        project_id=project.id,
+        task_id=first.id,
+        status=TaskStatus.DONE,
+    )
+    assert completed is not None
+    assert completed.status == TaskStatus.DONE
+
+    reordered = reorder_tasks(
+        session,
+        owner_id="user-a",
+        project_id=project.id,
+        task_ids=[second.id, first.id],
+    )
+    assert reordered is not None
+    assert [task.id for task in reordered] == [second.id, first.id]
+    assert (
+        reorder_tasks(
+            session,
+            owner_id="user-a",
+            project_id=project.id,
+            task_ids=[second.id, second.id, first.id],
+        )
+        is None
+    )
+
+    assert delete_task(session, owner_id="user-b", project_id=project.id, task_id=first.id) is False
+    assert delete_task(session, owner_id="user-a", project_id=project.id, task_id=first.id) is True
+    assert [task.id for task in list_tasks(session, owner_id="user-a", project_id=project.id)] == [second.id]
+
+    third = create_task(session, owner_id="user-a", project_id=project.id, title="Keep positions stable")
+
+    assert third is not None
+    assert third.position == 1
+
+
+def test_new_task_position_uses_max_existing_position(session: Session) -> None:
+    project = create_project(
+        session,
+        owner_id="user-a",
+        title="Keep task order",
+        goal_text="Avoid duplicate task positions",
+    )
+    assert project.id is not None
+
+    first = create_task(session, owner_id="user-a", project_id=project.id, title="First")
+    second = create_task(session, owner_id="user-a", project_id=project.id, title="Second")
+    third = create_task(session, owner_id="user-a", project_id=project.id, title="Third")
+    assert first is not None
+    assert second is not None
+    assert third is not None
+    assert first.id is not None
+    assert second.id is not None
+
+    assert delete_task(session, owner_id="user-a", project_id=project.id, task_id=second.id) is True
+
+    fourth = create_task(session, owner_id="user-a", project_id=project.id, title="Fourth")
+
+    assert fourth is not None
+    assert fourth.position == 3
+
+
+def test_task_parent_must_belong_to_same_owner_scoped_project(session: Session) -> None:
+    first_project = create_project(
+        session,
+        owner_id="user-a",
+        title="First project",
+        goal_text="Plan the first thing",
+    )
+    second_project = create_project(
+        session,
+        owner_id="user-a",
+        title="Second project",
+        goal_text="Plan the second thing",
+    )
+    other_owner_project = create_project(
+        session,
+        owner_id="user-b",
+        title="Other owner project",
+        goal_text="Plan a private thing",
+    )
+    assert first_project.id is not None
+    assert second_project.id is not None
+    assert other_owner_project.id is not None
+
+    parent = create_task(session, owner_id="user-a", project_id=first_project.id, title="Parent")
+    other_owner_parent = create_task(
+        session,
+        owner_id="user-b",
+        project_id=other_owner_project.id,
+        title="Private parent",
+    )
+    assert parent is not None
+    assert parent.id is not None
+    assert other_owner_parent is not None
+    assert other_owner_parent.id is not None
+
+    assert (
+        create_task(
+            session,
+            owner_id="user-a",
+            project_id=second_project.id,
+            parent_task_id=parent.id,
+            title="Cross-project child",
+        )
+        is None
+    )
+    assert (
+        create_task(
+            session,
+            owner_id="user-a",
+            project_id=first_project.id,
+            parent_task_id=other_owner_parent.id,
+            title="Cross-owner child",
+        )
+        is None
+    )
+
+    child = create_task(
+        session,
+        owner_id="user-a",
+        project_id=first_project.id,
+        parent_task_id=parent.id,
+        title="Valid child",
+    )
+    assert child is not None
+    assert child.parent_task_id == parent.id
+
+
+def test_deleting_task_removes_descendants(session: Session) -> None:
+    project = create_project(
+        session,
+        owner_id="user-a",
+        title="Remove hierarchy",
+        goal_text="Delete nested tasks cleanly",
+    )
+    assert project.id is not None
+
+    parent = create_task(session, owner_id="user-a", project_id=project.id, title="Parent")
+    assert parent is not None
+    assert parent.id is not None
+    child = create_task(
+        session,
+        owner_id="user-a",
+        project_id=project.id,
+        parent_task_id=parent.id,
+        title="Child",
+    )
+    assert child is not None
+    assert child.id is not None
+    grandchild = create_task(
+        session,
+        owner_id="user-a",
+        project_id=project.id,
+        parent_task_id=child.id,
+        title="Grandchild",
+    )
+    assert grandchild is not None
+
+    assert delete_task(session, owner_id="user-a", project_id=project.id, task_id=parent.id) is True
+
+    assert list_tasks(session, owner_id="user-a", project_id=project.id) == []
+
+
+def test_breakdown_runs_are_scoped_by_project_owner(session: Session) -> None:
+    project = create_project(
+        session,
+        owner_id="user-a",
+        title="Break down launch",
+        goal_text="Launch the first MVP",
+    )
+    assert project.id is not None
+
+    run = create_breakdown_run(
+        session,
+        owner_id="user-a",
+        project_id=project.id,
+        provider="mock",
+        model="mock-v1",
+        prompt_version="breakdown-v1",
+        input_goal=project.goal_text,
+        raw_response='{"tasks":[]}',
+    )
+
+    assert run is not None
+    assert run.id is not None
+    assert list_breakdown_runs(session, owner_id="user-a", project_id=project.id) == [run]
+    assert list_breakdown_runs(session, owner_id="user-b", project_id=project.id) == []
+
+    assert delete_project(session, owner_id="user-a", project_id=project.id) is True
+    assert list_breakdown_runs(session, owner_id="user-a", project_id=project.id) == []

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,7 @@
 # Architecture Notes
 
+## English
+
 ## Initial Stack
 
 - React frontend
@@ -47,7 +49,7 @@ koma-planner/
 - AI provider calls
 - AI response validation
 - API key storage and encryption when backend persistence is enabled
-- Authentication when added
+- Consume authenticated user identity when auth is added
 
 ## AI Breakdown Flow
 
@@ -64,4 +66,72 @@ User goal
 
 ## Early Deployment Assumption
 
-The first version can run locally. SaaS deployment and per-user app instances are deferred until the product experience is proven.
+The first version can run locally, but persisted data should still be scoped as private user data. Any network-accessible deployment should require login. Authentication will be implemented later in a separate self-hosted service, while Koma Planner keeps owner-scoped project records.
+
+## Japanese
+
+### 初期スタック
+
+- React frontend
+- FastAPI backend
+- SQLite database
+- SQLModel ORM
+- User-provided AI API keys
+
+### 提案レイアウト
+
+```text
+koma-planner/
+  AGENTS.md
+  .agents/
+    markdown.md
+    project-rules.md
+  apps/
+    web/
+    api/
+  docs/
+    product-brief.md
+    architecture.md
+    mvp-scope.md
+    data-model.md
+```
+
+### ローカルアプリ構成
+
+- `apps/web`: React + Vite frontend.
+- `apps/api`: FastAPI backend.
+- `docs/development.md`: local run commands and environment notes.
+
+### Frontend の責務
+
+- Goal input
+- Project list and project detail screens
+- Todo interaction: check, edit, add, delete, reorder
+- Breakdown review and regeneration controls
+- API key settings screen or modal
+
+### Backend の責務
+
+- Project persistence
+- Task persistence
+- AI provider calls
+- AI response validation
+- API key storage and encryption when backend persistence is enabled
+- 認証追加後は、認証済み user identity を受け取って project data を owner ごとに扱う
+
+### AI Breakdown Flow
+
+```text
+User goal
+  -> frontend sends breakdown request
+  -> backend loads provider settings
+  -> backend calls AI provider
+  -> backend validates structured response
+  -> backend returns normalized tasks
+  -> frontend renders tasks as editable todos
+  -> user saves project
+```
+
+### 初期 deployment 方針
+
+最初の version は local で動かせればよいですが、永続化データは最初から private user data として owner ごとにスコープします。ネットワークからアクセスできる deployment では login 必須にします。認証は後続で別の self-hosted service として実装し、Koma Planner は owner-scoped な project records を持ちます。

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,49 +1,35 @@
-# Data Model Draft
+# Data Model
 
-## Entities
+## English
 
-### User
+### Current Decision
 
-Deferred for the first local prototype, but the schema should leave room for it.
+Koma Planner should treat project data as private user data from the first persisted schema. The MVP may use a fixed development owner such as `dev-user`, but persisted projects must still be scoped by a required `owner_id`.
 
-Fields:
+Authentication is intentionally not implemented in MVP 02. A later self-hosted auth service should own login, sessions, and MFA, then provide an authenticated user identity to Koma Planner. Koma Planner maps that identity to `owner_id` and, later, `workspace_id`.
 
-- `id`
-- `email`
-- `display_name`
-- `created_at`
+TOTP is the likely first MFA candidate because it is mature and small enough to implement. WebAuthn/passkeys remain a possible later improvement.
 
-### ApiKey
+### Entities
 
-Stores provider credentials when backend persistence is enabled.
-
-Fields:
-
-- `id`
-- `user_id`
-- `provider`
-- `encrypted_api_key`
-- `default_model`
-- `created_at`
-- `updated_at`
-
-### Project
+#### Project
 
 Represents a saved goal and its task list.
 
 Fields:
 
 - `id`
-- `user_id`
+- `owner_id`
+- `workspace_id`
 - `title`
 - `goal_text`
 - `status`
 - `created_at`
 - `updated_at`
 
-### Task
+#### Task
 
-Represents one actionable todo item.
+Represents one actionable todo item in a project.
 
 Fields:
 
@@ -59,7 +45,7 @@ Fields:
 - `created_at`
 - `updated_at`
 
-### BreakdownRun
+#### BreakdownRun
 
 Records an AI generation event.
 
@@ -72,11 +58,102 @@ Fields:
 - `prompt_version`
 - `input_goal`
 - `raw_response`
+- `status`
 - `created_at`
 
-## Notes
+### Deferred Entities
 
+#### User
+
+User accounts are deferred to a later self-hosted authentication service. Koma Planner should not store password credentials in its own application database.
+
+#### ApiKey
+
+Provider credential storage is deferred until the API key configuration flow. If backend persistence is added later, keys must be encrypted and must never be returned to the frontend after saving.
+
+### Notes
+
+- `owner_id` is required so network-accessible deployments do not start from globally visible project data.
+- `workspace_id` is optional for now and leaves room for team or multi-workspace support.
 - `parent_task_id` allows later subtask support without requiring it in the first UI.
 - `position` keeps manual ordering stable.
 - `BreakdownRun` makes AI behavior easier to debug later.
-- API keys must not be stored in plaintext in production-like modes.
+
+## Japanese
+
+### 現在の決定
+
+Koma Planner は、永続化する最初のスキーマからプロジェクトデータをユーザーのプライベートデータとして扱います。MVP 中は `dev-user` のような固定開発用 owner を使ってもよいですが、保存される project は必ず `owner_id` でスコープされる必要があります。
+
+MVP 02 では認証そのものは実装しません。後続で self-hosted な認証サービスを別途作り、ログイン、セッション、MFA をそのサービスに持たせます。Koma Planner は、その認証サービスから受け取ったユーザー identity を `owner_id`、将来的には `workspace_id` に紐づけます。
+
+MFA は後で決めますが、最初の候補は実装が比較的小さく、枯れている TOTP です。WebAuthn/passkey は将来の改善候補として残します。
+
+### エンティティ
+
+#### Project
+
+保存された goal と task list を表します。
+
+フィールド:
+
+- `id`
+- `owner_id`
+- `workspace_id`
+- `title`
+- `goal_text`
+- `status`
+- `created_at`
+- `updated_at`
+
+#### Task
+
+Project 内の 1 つの実行可能な todo を表します。
+
+フィールド:
+
+- `id`
+- `project_id`
+- `parent_task_id`
+- `title`
+- `description`
+- `acceptance_criteria`
+- `status`
+- `position`
+- `estimate_minutes`
+- `created_at`
+- `updated_at`
+
+#### BreakdownRun
+
+AI による task breakdown の生成イベントを記録します。
+
+フィールド:
+
+- `id`
+- `project_id`
+- `provider`
+- `model`
+- `prompt_version`
+- `input_goal`
+- `raw_response`
+- `status`
+- `created_at`
+
+### 後回しにするエンティティ
+
+#### User
+
+ユーザーアカウントは、後続で作る self-hosted な認証サービスに任せます。Koma Planner 本体のアプリケーション DB には password credential を保存しません。
+
+#### ApiKey
+
+AI provider の credential 保存は API key 設定フローまで後回しにします。将来 backend に保存する場合は暗号化し、保存済み key を frontend に返してはいけません。
+
+### 補足
+
+- `owner_id` は必須です。ネットワークからアクセスできる deployment で、project data が全体公開扱いになる設計から始めないためです。
+- `workspace_id` は現時点では任意です。将来の team や multi-workspace support の余地を残します。
+- `parent_task_id` は、最初の UI に subtask を要求せずに将来の subtask support を可能にします。
+- `position` は手動並び替えの順序を安定させます。
+- `BreakdownRun` は AI の挙動を後から調べやすくします。

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,12 +1,14 @@
 # Development
 
-## Requirements
+## English
+
+### Requirements
 
 - Node.js 22 or newer
 - npm
 - Python 3.13 or newer
 
-## Frontend
+### Frontend
 
 ```powershell
 cd apps/web
@@ -22,7 +24,7 @@ From the repository root, you can also run:
 npm run dev:web
 ```
 
-## Backend
+### Backend
 
 ```powershell
 cd apps/api
@@ -46,7 +48,7 @@ Health check:
 Invoke-RestMethod http://127.0.0.1:8000/api/health
 ```
 
-## Verification
+### Verification
 
 Frontend build and type check:
 
@@ -60,9 +62,20 @@ Backend tests, after activating `apps/api/.venv`:
 npm run test:api
 ```
 
+On Windows, if the global `npm` shim or Python path is not pointing at the virtual environment, run the backend tests directly:
+
+```powershell
+cd apps/api
+.\.venv\Scripts\python.exe -m pytest -p no:cacheprovider tests
+```
+
 These same checks run in GitHub Actions for pull requests and pushes to `main`.
 
-## MVP 01 Test Rationale
+### MVP 02 Test Rationale
+
+MVP 02 adds the first persistence layer. Its backend tests cover database table creation, required owner scoping, project CRUD, task CRUD, and task reordering through internal repository functions.
+
+### MVP 01 Test Rationale
 
 MVP 01 is a scaffold ticket. It does not implement AI breakdowns, todo editing, persistence, authentication, or API key handling. Because of that, the test surface should prove that the two application entry points exist and can run, without pretending to validate product behavior that does not exist yet.
 
@@ -78,11 +91,105 @@ Together, these checks are sufficient for MVP 01 because the issue acceptance cr
 
 They are intentionally not sufficient for later MVP issues. Future tickets should add tests for their own behavior, such as database persistence, AI output validation, todo editing, save/reopen flows, and error handling.
 
-## MVP 01 Notes
+### MVP 01 Notes
 
 This issue only creates the runnable application structure. Persistence, AI breakdowns, and todo editing are handled by later MVP issues.
 
-## MVP 01 Definition Of Done
+### MVP 01 Definition Of Done
+
+- `apps/web` exists and builds with `npm run build:web`.
+- `apps/api` exists and exposes `GET /api/health`.
+- Backend health behavior is covered by `npm run test:api`.
+- Local run and verification commands are documented.
+
+## Japanese
+
+### 要件
+
+- Node.js 22 以上
+- npm
+- Python 3.13 以上
+
+### Frontend
+
+```powershell
+cd apps/web
+npm install
+npm run dev
+```
+
+React app は `http://127.0.0.1:5173` で起動します。
+
+Repository root からは次の command も使えます。
+
+```powershell
+npm run dev:web
+```
+
+### Backend
+
+```powershell
+cd apps/api
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install -r requirements-dev.txt
+python -m uvicorn app.main:app --reload
+```
+
+FastAPI app は `http://127.0.0.1:8000` で起動します。
+
+Repository root からは、`apps/api/.venv` を有効化した後に次の command も使えます。
+
+```powershell
+npm run dev:api
+```
+
+Health check:
+
+```powershell
+Invoke-RestMethod http://127.0.0.1:8000/api/health
+```
+
+### Verification
+
+Frontend build and type check:
+
+```powershell
+npm run build:web
+```
+
+Backend tests は、`apps/api/.venv` を有効化した後に実行します。
+
+```powershell
+npm run test:api
+```
+
+Windows で global `npm` shim や Python path が virtual environment を見ていない場合は、backend tests を直接実行します。
+
+```powershell
+cd apps/api
+.\.venv\Scripts\python.exe -m pytest -p no:cacheprovider tests
+```
+
+同じ check は、pull request と `main` への push で GitHub Actions でも実行されます。
+
+### MVP 02 Test Rationale
+
+MVP 02 は最初の persistence layer を追加します。Backend tests では、database table creation、必須の owner scoping、project CRUD、task CRUD、task reordering を internal repository functions 経由で確認します。
+
+### MVP 01 Test Rationale
+
+MVP 01 は scaffold ticket です。AI breakdown、todo editing、persistence、authentication、API key handling はまだ実装しません。そのため、test surface は frontend と backend の entry point が存在し、起動できることを確認する範囲に留めます。
+
+Frontend check は `npm run build:web` です。React/Vite app が compile でき、TypeScript が current source を受け入れ、production bundle を `apps/web` から生成できることを確認します。
+
+Backend check は `npm run test:api` です。現時点では `GET /api/health` を検証し、FastAPI app が import でき、router が wire され、最初の API endpoint が期待する response shape を返すことを確認します。
+
+### MVP 01 Notes
+
+この issue は runnable application structure だけを作ります。Persistence、AI breakdown、todo editing は後続の MVP issue で扱います。
+
+### MVP 01 Definition Of Done
 
 - `apps/web` exists and builds with `npm run build:web`.
 - `apps/api` exists and exposes `GET /api/health`.


### PR DESCRIPTION
## Summary

- Add bilingual documentation rules and update architecture, data model, development, and README docs in English and Japanese.
- Add SQLModel models for owner-scoped `Project`, `Task`, and `BreakdownRun` records.
- Add SQLite database initialization and repository helpers for project, task, reorder, and breakdown run persistence.
- Initialize database tables during FastAPI startup.
- Add focused backend persistence tests for owner scoping, CRUD, task reordering, parent task ownership, descendant deletion, and breakdown run visibility.

## Review fixes

- Prevent new task positions from colliding after deletions by assigning the next position from the current maximum.
- Reject cross-project or cross-owner `parent_task_id` values.
- Reject duplicate task IDs in reorder requests.
- Delete descendant tasks before deleting a parent task or project.

## Validation

- `apps/api/.venv/Scripts/python.exe -m pytest -p no:cacheprovider tests` from `apps/api` -> 8 passed
- `C:\Program Files\nodejs\npm.cmd run build:web` -> passed
- GitHub Actions on PR #12 -> Backend tests passed, Frontend build passed

Closes #2
