### PR TITLE
[codex] Add MVP 03 project and task API

### DIFF
--- a/apps/api/app/api.py
+++ b/apps/api/app/api.py
@@ -1,0 +1,222 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
+from sqlmodel import Session
+
+from app.database import get_session
+from app.models import Project, Task, TaskStatus
+from app.repositories import (
+    create_project,
+    create_task,
+    delete_project,
+    delete_task,
+    get_project,
+    list_projects,
+    list_tasks,
+    reorder_tasks,
+    update_project,
+    update_task,
+)
+from app.schemas import (
+    ProjectCreate,
+    ProjectDetailRead,
+    ProjectRead,
+    ProjectUpdate,
+    TaskCompletionUpdate,
+    TaskCreate,
+    TaskRead,
+    TaskReorder,
+    TaskUpdate,
+)
+
+
+router = APIRouter(prefix="/api")
+
+
+def get_owner_id(x_koma_owner_id: Annotated[str | None, Header()] = None) -> str:
+    if x_koma_owner_id is None:
+        return "dev-user"
+    owner_id = x_koma_owner_id.strip()
+    if not owner_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="X-Koma-Owner-Id is required")
+    return owner_id
+
+
+OwnerId = Annotated[str, Depends(get_owner_id)]
+DbSession = Annotated[Session, Depends(get_session)]
+
+
+@router.post("/projects", response_model=ProjectDetailRead, status_code=status.HTTP_201_CREATED)
+def create_project_endpoint(payload: ProjectCreate, owner_id: OwnerId, session: DbSession) -> ProjectDetailRead:
+    project = create_project(
+        session,
+        owner_id=owner_id,
+        title=payload.title,
+        goal_text=payload.goal_text,
+        workspace_id=payload.workspace_id,
+    )
+    for task_payload in payload.tasks:
+        task = create_task(
+            session,
+            owner_id=owner_id,
+            project_id=_require_id(project),
+            title=task_payload.title,
+            description=task_payload.description,
+            acceptance_criteria=task_payload.acceptance_criteria,
+            parent_task_id=task_payload.parent_task_id,
+            position=task_payload.position,
+            estimate_minutes=task_payload.estimate_minutes,
+        )
+        if task is None:
+            delete_project(session, owner_id=owner_id, project_id=_require_id(project))
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid initial task")
+    return _project_detail(session, owner_id=owner_id, project=project)
+
+
+@router.get("/projects", response_model=list[ProjectRead])
+def list_projects_endpoint(owner_id: OwnerId, session: DbSession) -> list[Project]:
+    return list_projects(session, owner_id=owner_id)
+
+
+@router.get("/projects/{project_id}", response_model=ProjectDetailRead)
+def get_project_endpoint(project_id: int, owner_id: OwnerId, session: DbSession) -> ProjectDetailRead:
+    project = _get_project_or_404(session, owner_id=owner_id, project_id=project_id)
+    return _project_detail(session, owner_id=owner_id, project=project)
+
+
+@router.patch("/projects/{project_id}", response_model=ProjectDetailRead)
+def update_project_endpoint(
+    project_id: int,
+    payload: ProjectUpdate,
+    owner_id: OwnerId,
+    session: DbSession,
+) -> ProjectDetailRead:
+    project = update_project(
+        session,
+        owner_id=owner_id,
+        project_id=project_id,
+        title=payload.title,
+        goal_text=payload.goal_text,
+        status=payload.status,
+    )
+    if project is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Project not found")
+    return _project_detail(session, owner_id=owner_id, project=project)
+
+
+@router.delete("/projects/{project_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_project_endpoint(project_id: int, owner_id: OwnerId, session: DbSession) -> Response:
+    if not delete_project(session, owner_id=owner_id, project_id=project_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Project not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/projects/{project_id}/tasks", response_model=TaskRead, status_code=status.HTTP_201_CREATED)
+def create_task_endpoint(
+    project_id: int,
+    payload: TaskCreate,
+    owner_id: OwnerId,
+    session: DbSession,
+) -> Task:
+    task = create_task(
+        session,
+        owner_id=owner_id,
+        project_id=project_id,
+        title=payload.title,
+        description=payload.description,
+        acceptance_criteria=payload.acceptance_criteria,
+        parent_task_id=payload.parent_task_id,
+        position=payload.position,
+        estimate_minutes=payload.estimate_minutes,
+    )
+    if task is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Project or parent task not found")
+    return task
+
+
+@router.patch("/projects/{project_id}/tasks/reorder", response_model=list[TaskRead])
+def reorder_tasks_endpoint(
+    project_id: int,
+    payload: TaskReorder,
+    owner_id: OwnerId,
+    session: DbSession,
+) -> list[Task]:
+    _get_project_or_404(session, owner_id=owner_id, project_id=project_id)
+    tasks = reorder_tasks(session, owner_id=owner_id, project_id=project_id, task_ids=payload.task_ids)
+    if tasks is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Task IDs must match the project tasks")
+    return tasks
+
+
+@router.patch("/projects/{project_id}/tasks/{task_id}", response_model=TaskRead)
+def update_task_endpoint(
+    project_id: int,
+    task_id: int,
+    payload: TaskUpdate,
+    owner_id: OwnerId,
+    session: DbSession,
+) -> Task:
+    task = update_task(
+        session,
+        owner_id=owner_id,
+        project_id=project_id,
+        task_id=task_id,
+        title=payload.title,
+        description=payload.description,
+        acceptance_criteria=payload.acceptance_criteria,
+        status=payload.status,
+        position=payload.position,
+        estimate_minutes=payload.estimate_minutes,
+    )
+    if task is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
+    return task
+
+
+@router.patch("/projects/{project_id}/tasks/{task_id}/completion", response_model=TaskRead)
+def update_task_completion_endpoint(
+    project_id: int,
+    task_id: int,
+    payload: TaskCompletionUpdate,
+    owner_id: OwnerId,
+    session: DbSession,
+) -> Task:
+    task = update_task(
+        session,
+        owner_id=owner_id,
+        project_id=project_id,
+        task_id=task_id,
+        status=TaskStatus.DONE if payload.completed else TaskStatus.TODO,
+    )
+    if task is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
+    return task
+
+
+@router.delete("/projects/{project_id}/tasks/{task_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_task_endpoint(project_id: int, task_id: int, owner_id: OwnerId, session: DbSession) -> Response:
+    if not delete_task(session, owner_id=owner_id, project_id=project_id, task_id=task_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+def _project_detail(session: Session, *, owner_id: str, project: Project) -> ProjectDetailRead:
+    return ProjectDetailRead.model_validate(
+        {
+            **ProjectRead.model_validate(project).model_dump(),
+            "tasks": list_tasks(session, owner_id=owner_id, project_id=_require_id(project)),
+        }
+    )
+
+
+def _get_project_or_404(session: Session, *, owner_id: str, project_id: int) -> Project:
+    project = get_project(session, owner_id=owner_id, project_id=project_id)
+    if project is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Project not found")
+    return project
+
+
+def _require_id(project: Project) -> int:
+    if project.id is None:
+        raise RuntimeError("Project was not persisted")
+    return project.id

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -4,6 +4,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.api import router as api_router
 from app.database import create_db_and_tables
 
 
@@ -27,3 +28,6 @@ app.add_middleware(
 @app.get("/api/health")
 def health_check() -> dict[str, str]:
     return {"status": "ok"}
+
+
+app.include_router(api_router)

--- a/apps/api/app/schemas.py
+++ b/apps/api/app/schemas.py
@@ -1,0 +1,114 @@
+from datetime import datetime
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
+
+from app.models import ProjectStatus, TaskStatus
+
+
+class TaskCreate(BaseModel):
+    title: str = Field(min_length=1, max_length=200)
+    description: str | None = None
+    acceptance_criteria: str | None = None
+    parent_task_id: int | None = None
+    position: int | None = Field(default=None, ge=0)
+    estimate_minutes: int | None = Field(default=None, ge=0)
+
+    @field_validator("title")
+    @classmethod
+    def title_must_not_be_blank(cls, value: str) -> str:
+        return _require_text(value, "title")
+
+
+class TaskUpdate(BaseModel):
+    title: str | None = Field(default=None, min_length=1, max_length=200)
+    description: str | None = None
+    acceptance_criteria: str | None = None
+    status: TaskStatus | None = None
+    position: int | None = Field(default=None, ge=0)
+    estimate_minutes: int | None = Field(default=None, ge=0)
+
+    @field_validator("title")
+    @classmethod
+    def title_must_not_be_blank(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _require_text(value, "title")
+
+
+class TaskCompletionUpdate(BaseModel):
+    completed: bool
+
+
+class TaskReorder(BaseModel):
+    task_ids: list[int] = Field(min_length=1)
+
+
+class TaskRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    project_id: int
+    parent_task_id: int | None
+    title: str
+    description: str | None
+    acceptance_criteria: str | None
+    status: TaskStatus
+    position: int
+    estimate_minutes: int | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class ProjectCreate(BaseModel):
+    title: str = Field(min_length=1, max_length=200)
+    goal_text: str = Field(min_length=1)
+    workspace_id: str | None = None
+    tasks: list[TaskCreate] = Field(default_factory=list)
+
+    @field_validator("title", "goal_text")
+    @classmethod
+    def text_must_not_be_blank(cls, value: str, info: ValidationInfo) -> str:
+        return _require_text(value, info.field_name)
+
+    @field_validator("workspace_id")
+    @classmethod
+    def optional_text_must_not_be_blank(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _require_text(value, "workspace_id")
+
+
+class ProjectUpdate(BaseModel):
+    title: str | None = Field(default=None, min_length=1, max_length=200)
+    goal_text: str | None = Field(default=None, min_length=1)
+    status: ProjectStatus | None = None
+
+    @field_validator("title", "goal_text")
+    @classmethod
+    def text_must_not_be_blank(cls, value: str | None, info: ValidationInfo) -> str | None:
+        if value is None:
+            return None
+        return _require_text(value, info.field_name)
+
+
+class ProjectRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    owner_id: str
+    workspace_id: str | None
+    title: str
+    goal_text: str
+    status: ProjectStatus
+    created_at: datetime
+    updated_at: datetime
+
+
+class ProjectDetailRead(ProjectRead):
+    tasks: list[TaskRead]
+
+
+def _require_text(value: str, field_name: str) -> str:
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError(f"{field_name} is required")
+    return stripped

--- a/apps/api/tests/test_project_task_api.py
+++ b/apps/api/tests/test_project_task_api.py
@@ -1,0 +1,236 @@
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine
+
+from app.database import create_db_and_tables, get_session
+from app.main import app
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    create_db_and_tables(engine)
+
+    def override_get_session() -> Iterator[Session]:
+        with Session(engine) as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+    with TestClient(app) as test_client:
+        yield test_client
+    app.dependency_overrides.clear()
+    SQLModel.metadata.drop_all(engine)
+
+
+def test_create_project_with_initial_tasks_and_reopen(client: TestClient) -> None:
+    response = client.post(
+        "/api/projects",
+        headers={"X-Koma-Owner-Id": "user-a"},
+        json={
+            "title": "Launch MVP",
+            "goal_text": "Launch a small planner MVP",
+            "tasks": [
+                {
+                    "title": "Draft the API",
+                    "description": "Write the first endpoint contract",
+                    "acceptance_criteria": "Endpoints are documented",
+                    "estimate_minutes": 30,
+                },
+                {"title": "Build the endpoints"},
+            ],
+        },
+    )
+
+    assert response.status_code == 201
+    created = response.json()
+    assert created["id"] is not None
+    assert created["owner_id"] == "user-a"
+    assert created["title"] == "Launch MVP"
+    assert [task["title"] for task in created["tasks"]] == [
+        "Draft the API",
+        "Build the endpoints",
+    ]
+    assert [task["position"] for task in created["tasks"]] == [0, 1]
+    assert created["tasks"][0]["status"] == "todo"
+
+    list_response = client.get("/api/projects", headers={"X-Koma-Owner-Id": "user-a"})
+    assert list_response.status_code == 200
+    assert list_response.json()[0]["id"] == created["id"]
+    assert "tasks" not in list_response.json()[0]
+
+    detail_response = client.get(
+        f"/api/projects/{created['id']}",
+        headers={"X-Koma-Owner-Id": "user-a"},
+    )
+    assert detail_response.status_code == 200
+    assert detail_response.json()["tasks"][0]["description"] == "Write the first endpoint contract"
+
+    other_owner_list = client.get("/api/projects", headers={"X-Koma-Owner-Id": "user-b"})
+    assert other_owner_list.status_code == 200
+    assert other_owner_list.json() == []
+
+    other_owner_detail = client.get(
+        f"/api/projects/{created['id']}",
+        headers={"X-Koma-Owner-Id": "user-b"},
+    )
+    assert other_owner_detail.status_code == 404
+
+
+def test_project_update_and_delete_are_owner_scoped(client: TestClient) -> None:
+    created = client.post(
+        "/api/projects",
+        json={"title": "Original", "goal_text": "Plan the original goal"},
+    ).json()
+
+    blocked_update = client.patch(
+        f"/api/projects/{created['id']}",
+        headers={"X-Koma-Owner-Id": "user-b"},
+        json={"title": "Private edit"},
+    )
+    assert blocked_update.status_code == 404
+
+    update_response = client.patch(
+        f"/api/projects/{created['id']}",
+        json={"title": "Updated", "goal_text": "Plan the updated goal"},
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["title"] == "Updated"
+    assert update_response.json()["goal_text"] == "Plan the updated goal"
+
+    blocked_delete = client.delete(
+        f"/api/projects/{created['id']}",
+        headers={"X-Koma-Owner-Id": "user-b"},
+    )
+    assert blocked_delete.status_code == 404
+
+    delete_response = client.delete(f"/api/projects/{created['id']}")
+    assert delete_response.status_code == 204
+    assert client.get(f"/api/projects/{created['id']}").status_code == 404
+
+
+def test_task_edit_completion_and_reopen_persist(client: TestClient) -> None:
+    project = client.post(
+        "/api/projects",
+        json={"title": "Task edits", "goal_text": "Check task persistence"},
+    ).json()
+    task_response = client.post(
+        f"/api/projects/{project['id']}/tasks",
+        json={"title": "First title"},
+    )
+    assert task_response.status_code == 201
+    task = task_response.json()
+
+    edited_response = client.patch(
+        f"/api/projects/{project['id']}/tasks/{task['id']}",
+        json={
+            "title": "Edited title",
+            "description": "Edited description",
+            "acceptance_criteria": "The edit is saved",
+            "estimate_minutes": 45,
+        },
+    )
+    assert edited_response.status_code == 200
+    assert edited_response.json()["title"] == "Edited title"
+    assert edited_response.json()["estimate_minutes"] == 45
+
+    checked_response = client.patch(
+        f"/api/projects/{project['id']}/tasks/{task['id']}/completion",
+        json={"completed": True},
+    )
+    assert checked_response.status_code == 200
+    assert checked_response.json()["status"] == "done"
+
+    unchecked_response = client.patch(
+        f"/api/projects/{project['id']}/tasks/{task['id']}/completion",
+        json={"completed": False},
+    )
+    assert unchecked_response.status_code == 200
+    assert unchecked_response.json()["status"] == "todo"
+
+    reopened = client.get(f"/api/projects/{project['id']}").json()
+    assert reopened["tasks"][0]["title"] == "Edited title"
+    assert reopened["tasks"][0]["description"] == "Edited description"
+    assert reopened["tasks"][0]["status"] == "todo"
+
+
+def test_task_reorder_and_delete(client: TestClient) -> None:
+    project = client.post(
+        "/api/projects",
+        json={
+            "title": "Order tasks",
+            "goal_text": "Keep task order stable",
+            "tasks": [
+                {"title": "First"},
+                {"title": "Second"},
+                {"title": "Third"},
+            ],
+        },
+    ).json()
+    tasks = project["tasks"]
+
+    bad_reorder = client.patch(
+        f"/api/projects/{project['id']}/tasks/reorder",
+        json={"task_ids": [tasks[2]["id"], tasks[0]["id"]]},
+    )
+    assert bad_reorder.status_code == 400
+
+    reorder_response = client.patch(
+        f"/api/projects/{project['id']}/tasks/reorder",
+        json={"task_ids": [tasks[2]["id"], tasks[0]["id"], tasks[1]["id"]]},
+    )
+    assert reorder_response.status_code == 200
+    assert [task["title"] for task in reorder_response.json()] == ["Third", "First", "Second"]
+    assert [task["position"] for task in reorder_response.json()] == [0, 1, 2]
+
+    delete_response = client.delete(f"/api/projects/{project['id']}/tasks/{tasks[0]['id']}")
+    assert delete_response.status_code == 204
+
+    reopened = client.get(f"/api/projects/{project['id']}").json()
+    assert [task["title"] for task in reopened["tasks"]] == ["Third", "Second"]
+
+
+def test_api_validation_errors_are_clear(client: TestClient) -> None:
+    invalid_project = client.post(
+        "/api/projects",
+        json={"title": "   ", "goal_text": "Plan something"},
+    )
+    assert invalid_project.status_code == 422
+    assert "title" in str(invalid_project.json()["detail"])
+
+    missing_task_project = client.post(
+        "/api/projects/404/tasks",
+        json={"title": "Task for missing project"},
+    )
+    assert missing_task_project.status_code == 404
+
+    project = client.post(
+        "/api/projects",
+        json={"title": "Validation", "goal_text": "Validate bad task input"},
+    ).json()
+    invalid_task = client.post(
+        f"/api/projects/{project['id']}/tasks",
+        json={"title": ""},
+    )
+    assert invalid_task.status_code == 422
+    assert "title" in str(invalid_task.json()["detail"])
+
+
+def test_invalid_initial_task_does_not_leave_partial_project(client: TestClient) -> None:
+    response = client.post(
+        "/api/projects",
+        json={
+            "title": "Invalid initial tasks",
+            "goal_text": "Do not save partial AI output",
+            "tasks": [{"title": "Child without parent", "parent_task_id": 999}],
+        },
+    )
+
+    assert response.status_code == 400
+    assert client.get("/api/projects").json() == []

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,97 @@
+# API Contract
+
+## English
+
+### Current Decision
+
+MVP 03 exposes the persisted project and task operations through FastAPI under
+the `/api` prefix.
+
+Authentication is still deferred. Until authentication middleware exists, API
+requests are scoped by the `X-Koma-Owner-Id` header. If the header is omitted,
+the backend uses the temporary development owner `dev-user`. This keeps the
+first public API aligned with the required `owner_id` data model without
+building the later auth service in this issue.
+
+### Project Endpoints
+
+- `POST /api/projects`
+  - Creates a project.
+  - Accepts optional initial tasks so the frontend can save a generated todo
+    list in one request.
+- `GET /api/projects`
+  - Lists projects for the current owner.
+- `GET /api/projects/{project_id}`
+  - Returns one project with its tasks.
+- `PATCH /api/projects/{project_id}`
+  - Updates editable project fields.
+- `DELETE /api/projects/{project_id}`
+  - Deletes the project and its related tasks and breakdown runs.
+
+### Task Endpoints
+
+- `POST /api/projects/{project_id}/tasks`
+  - Creates a task in a project.
+- `PATCH /api/projects/{project_id}/tasks/{task_id}`
+  - Updates editable task fields, including status and position.
+- `PATCH /api/projects/{project_id}/tasks/{task_id}/completion`
+  - Checks or unchecks a task with a boolean `completed` field.
+- `PATCH /api/projects/{project_id}/tasks/reorder`
+  - Persists the exact task order for a project.
+- `DELETE /api/projects/{project_id}/tasks/{task_id}`
+  - Deletes a task and its descendants.
+
+### Validation
+
+Request bodies use typed schemas. Empty required text fields are rejected before
+data reaches the repository layer. Missing owner-scoped records return `404`.
+Invalid task reorder payloads return `400` because the task ID list must match
+the project's current task set exactly.
+
+## Japanese
+
+### 現在の決定
+
+MVP 03 では、永続化済みの project / task 操作を FastAPI の `/api` prefix
+配下で公開します。
+
+認証 middleware はまだ後続に回します。それまでの API request は
+`X-Koma-Owner-Id` header で owner scope を決めます。Header がない場合は、
+開発用の一時 owner である `dev-user` を使います。これにより、この issue で
+後続の auth service を作らずに、最初の public API を必須 `owner_id` data
+model と揃えます。
+
+### Project Endpoints
+
+- `POST /api/projects`
+  - Project を作成します。
+  - Frontend が generated todo list を 1 request で保存できるように、
+    initial tasks を任意で受け取ります。
+- `GET /api/projects`
+  - 現在の owner の projects を一覧します。
+- `GET /api/projects/{project_id}`
+  - 1 つの project と tasks を返します。
+- `PATCH /api/projects/{project_id}`
+  - Project の編集可能な fields を更新します。
+- `DELETE /api/projects/{project_id}`
+  - Project と関連する tasks / breakdown runs を削除します。
+
+### Task Endpoints
+
+- `POST /api/projects/{project_id}/tasks`
+  - Project に task を作成します。
+- `PATCH /api/projects/{project_id}/tasks/{task_id}`
+  - Status や position を含む task の編集可能な fields を更新します。
+- `PATCH /api/projects/{project_id}/tasks/{task_id}/completion`
+  - Boolean の `completed` field で task を check / uncheck します。
+- `PATCH /api/projects/{project_id}/tasks/reorder`
+  - Project の task order を保存します。
+- `DELETE /api/projects/{project_id}/tasks/{task_id}`
+  - Task とその descendants を削除します。
+
+### Validation
+
+Request body は typed schema を使います。必須 text field が空の場合は、
+repository layer に届く前に reject します。Owner scope 内に record がない場合は
+`404` を返します。不正な task reorder payload は `400` を返します。Task ID list
+は project の現在の task set と完全に一致する必要があります。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,10 +46,21 @@ koma-planner/
 
 - Project persistence
 - Task persistence
+- Project and task API endpoints
 - AI provider calls
 - AI response validation
 - API key storage and encryption when backend persistence is enabled
 - Consume authenticated user identity when auth is added
+
+## MVP 03 API Direction
+
+Until authentication middleware is added, FastAPI endpoints use the
+`X-Koma-Owner-Id` request header as a temporary owner scope bridge. Requests
+without the header use `dev-user`. This is intentionally local-prototype
+behavior; network-accessible deployments still require real authentication
+before private project data is exposed.
+
+See `docs/api.md` for the current endpoint contract.
 
 ## AI Breakdown Flow
 
@@ -114,10 +125,20 @@ koma-planner/
 
 - Project persistence
 - Task persistence
+- Project and task API endpoints
 - AI provider calls
 - AI response validation
 - API key storage and encryption when backend persistence is enabled
 - 認証追加後は、認証済み user identity を受け取って project data を owner ごとに扱う
+
+### MVP 03 API 方針
+
+認証 middleware を追加するまでは、FastAPI endpoints は `X-Koma-Owner-Id`
+request header を一時的な owner scope bridge として使います。Header がない場合は
+`dev-user` を使います。これは local prototype 用の挙動です。Network-accessible
+deployment では、private project data を公開する前に real authentication が必要です。
+
+現在の endpoint contract は `docs/api.md` を参照してください。
 
 ### AI Breakdown Flow
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -71,6 +71,13 @@ cd apps/api
 
 These same checks run in GitHub Actions for pull requests and pushes to `main`.
 
+### MVP 03 Test Rationale
+
+MVP 03 exposes the existing persistence layer through FastAPI. Its backend
+tests should cover owner-scoped project endpoints, project creation with
+initial tasks, project reopen behavior, task editing, task completion toggles,
+task reordering, task deletion, and clear validation/error responses.
+
 ### MVP 02 Test Rationale
 
 MVP 02 adds the first persistence layer. Its backend tests cover database table creation, required owner scoping, project CRUD, task CRUD, and task reordering through internal repository functions.
@@ -172,6 +179,13 @@ cd apps/api
 ```
 
 同じ check は、pull request と `main` への push で GitHub Actions でも実行されます。
+
+### MVP 03 Test Rationale
+
+MVP 03 は既存の persistence layer を FastAPI から公開します。Backend tests では、
+owner-scoped project endpoints、initial tasks 付き project creation、project
+reopen behavior、task editing、task completion toggle、task reorder、task deletion、
+明確な validation/error response を確認します。
 
 ### MVP 02 Test Rationale
 


### PR DESCRIPTION
## Summary

- Document the MVP 03 project/task API contract in English and Japanese.
- Add typed FastAPI request/response schemas and owner-scoped project/task endpoints.
- Cover project save/reopen, task edit/check/reorder/delete, owner scoping, and validation behavior with focused backend tests.

Closes #3

## Validation

- npm run build:web
- npm run test:api with apps/api/.venv/Scripts first in PATH
- apps/api/.venv/Scripts/python.exe -m pytest -p no:cacheprovider tests