### PR TITLE
[codex] Add MVP 04 breakdown contract

### DIFF
--- a/.agents/issue-workflow.md
+++ b/.agents/issue-workflow.md
@@ -1,0 +1,52 @@
+# Issue Implementation Workflow
+
+## English
+
+Use this flow for MVP issue implementation unless the user asks for a different
+path.
+
+1. Confirm the issue, dependencies, current branch, and clean working tree.
+2. Create a dedicated `codex/` branch before editing.
+3. Update or create project documentation first, including English and Japanese
+   sections when product, architecture, data model, setup, security, or API
+   decisions change.
+4. Write focused tests before implementation.
+5. Implement the smallest readable slice that satisfies the issue acceptance
+   criteria.
+6. Run local validation:
+   - `npm run build:web`
+   - `npm run test:api` with `apps/api/.venv/Scripts` first in `PATH`, or
+     `apps/api/.venv/Scripts/python.exe -m pytest -p no:cacheprovider tests`
+     directly on Windows.
+7. Review the diff for behavior, validation, docs drift, and test coverage.
+8. If problems appear, fix them and repeat test and review.
+9. Stage only the intended issue files, commit, push, and open a draft PR.
+10. Watch GitHub Actions.
+11. If CI fails, inspect logs, fix locally, rerun tests, push, and watch CI
+    again.
+12. When local review and CI are clean, mark the PR ready, do a final review,
+    squash merge, delete the remote branch, and update local `main`.
+
+## Japanese
+
+ユーザーから別の進め方を指定されない限り、MVP issue の実装ではこの流れを使います。
+
+1. Issue、dependencies、current branch、clean working tree を確認する。
+2. 編集前に専用の `codex/` branch を作る。
+3. 最初に project documentation を更新または作成する。Product、architecture、
+   data model、setup、security、API decision が変わる場合は English と Japanese
+   の両方を書く。
+4. 実装前に focused tests を書く。
+5. Issue acceptance criteria を満たす、最小で読みやすい実装を作る。
+6. Local validation を実行する:
+   - `npm run build:web`
+   - `apps/api/.venv/Scripts` を `PATH` の先頭にした `npm run test:api`、または
+     Windows では `apps/api/.venv/Scripts/python.exe -m pytest -p no:cacheprovider tests`
+     を直接実行する。
+7. Diff を behavior、validation、docs drift、test coverage の観点で review する。
+8. 問題があれば修正し、test と review を繰り返す。
+9. 対象 issue の files だけを stage し、commit、push、draft PR 作成を行う。
+10. GitHub Actions を監視する。
+11. CI が失敗したら logs を確認し、local fix、test、push、CI 監視を繰り返す。
+12. Local review と CI が clean になったら PR を ready にし、final review 後に
+    squash merge、remote branch delete、local `main` update まで行う。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ The product should feel less like a project-management suite and more like a wor
 
 - Markdown style: `.agents/markdown.md`
 - Project rules: `.agents/project-rules.md`
+- Issue implementation workflow: `.agents/issue-workflow.md`
 - Product brief: `docs/product-brief.md`
 - Architecture notes: `docs/architecture.md`
 - MVP scope: `docs/mvp-scope.md`

--- a/apps/api/app/api.py
+++ b/apps/api/app/api.py
@@ -3,9 +3,18 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
 from sqlmodel import Session
 
+from app.breakdowns import (
+    MOCK_MODEL,
+    MOCK_PROVIDER,
+    PROMPT_VERSION,
+    BreakdownValidationError,
+    build_mock_provider_response,
+    parse_provider_breakdown,
+)
 from app.database import get_session
 from app.models import Project, Task, TaskStatus
 from app.repositories import (
+    create_breakdown_run,
     create_project,
     create_task,
     delete_project,
@@ -18,6 +27,9 @@ from app.repositories import (
     update_task,
 )
 from app.schemas import (
+    BreakdownRequest,
+    BreakdownResponse,
+    BreakdownTaskRead,
     ProjectCreate,
     ProjectDetailRead,
     ProjectRead,
@@ -44,6 +56,47 @@ def get_owner_id(x_koma_owner_id: Annotated[str | None, Header()] = None) -> str
 
 OwnerId = Annotated[str, Depends(get_owner_id)]
 DbSession = Annotated[Session, Depends(get_session)]
+
+
+@router.post("/breakdowns", response_model=BreakdownResponse)
+def create_breakdown_endpoint(payload: BreakdownRequest, owner_id: OwnerId, session: DbSession) -> BreakdownResponse:
+    provider = payload.provider
+    model = payload.model or (MOCK_MODEL if provider == MOCK_PROVIDER else "")
+    if provider != MOCK_PROVIDER:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Only the mock provider is available")
+
+    if payload.project_id is not None:
+        _get_project_or_404(session, owner_id=owner_id, project_id=payload.project_id)
+
+    raw_response = build_mock_provider_response(payload.goal_text)
+    try:
+        tasks = parse_provider_breakdown(raw_response)
+    except BreakdownValidationError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
+
+    breakdown_run_id: int | None = None
+    if payload.project_id is not None:
+        breakdown_run = create_breakdown_run(
+            session,
+            owner_id=owner_id,
+            project_id=payload.project_id,
+            provider=provider,
+            model=model,
+            prompt_version=PROMPT_VERSION,
+            input_goal=payload.goal_text,
+            raw_response=raw_response,
+        )
+        if breakdown_run is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Project not found")
+        breakdown_run_id = breakdown_run.id
+
+    return BreakdownResponse(
+        provider=provider,
+        model=model,
+        prompt_version=PROMPT_VERSION,
+        breakdown_run_id=breakdown_run_id,
+        tasks=[BreakdownTaskRead.model_validate(task.model_dump()) for task in tasks],
+    )
 
 
 @router.post("/projects", response_model=ProjectDetailRead, status_code=status.HTTP_201_CREATED)

--- a/apps/api/app/breakdowns.py
+++ b/apps/api/app/breakdowns.py
@@ -1,0 +1,126 @@
+import json
+from pydantic import BaseModel, Field, ValidationError, field_validator
+
+
+PROMPT_VERSION = "breakdown-v1"
+MOCK_PROVIDER = "mock"
+MOCK_MODEL = "mock-breakdown-v1"
+
+
+class BreakdownValidationError(ValueError):
+    pass
+
+
+class NormalizedBreakdownTask(BaseModel):
+    title: str = Field(min_length=1, max_length=200)
+    description: str | None = None
+    acceptance_criteria: str | None = None
+    position: int = Field(ge=0)
+    estimate_minutes: int | None = Field(default=None, ge=0)
+
+    @field_validator("title")
+    @classmethod
+    def title_must_not_be_blank(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("title is required")
+        return stripped
+
+    @field_validator("description", "acceptance_criteria")
+    @classmethod
+    def optional_text_must_not_be_blank(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+
+class _ProviderTask(BaseModel):
+    title: str = Field(min_length=1, max_length=200)
+    description: str | None = None
+    acceptance_criteria: str | None = None
+    position: int | None = Field(default=None, ge=0)
+    estimate_minutes: int | None = Field(default=None, ge=0)
+
+    @field_validator("title")
+    @classmethod
+    def title_must_not_be_blank(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("title is required")
+        return stripped
+
+    @field_validator("description", "acceptance_criteria")
+    @classmethod
+    def optional_text_must_not_be_blank(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+
+class _ProviderBreakdown(BaseModel):
+    tasks: list[_ProviderTask] = Field(min_length=1)
+
+
+def build_mock_provider_response(goal_text: str) -> str:
+    goal = _require_text(goal_text, "goal_text")
+    payload = {
+        "tasks": [
+            {
+                "title": "Clarify the goal",
+                "description": f"Restate the desired outcome for: {goal}",
+                "acceptance_criteria": "The goal is specific enough to choose the next action.",
+                "estimate_minutes": 10,
+            },
+            {
+                "title": "List the first constraints",
+                "description": "Identify time, budget, tools, and any hard requirements.",
+                "acceptance_criteria": "At least three concrete constraints are written down.",
+                "estimate_minutes": 15,
+            },
+            {
+                "title": "Choose the smallest useful milestone",
+                "description": "Pick a result that can prove progress without expanding scope.",
+                "acceptance_criteria": "The milestone can be checked in one short review.",
+                "estimate_minutes": 20,
+            },
+            {
+                "title": "Start the first task",
+                "description": "Do the smallest action that moves the milestone forward.",
+                "acceptance_criteria": "There is visible progress or a clear blocker.",
+                "estimate_minutes": 25,
+            },
+        ]
+    }
+    return json.dumps(payload)
+
+
+def parse_provider_breakdown(raw_response: str) -> list[NormalizedBreakdownTask]:
+    try:
+        parsed = json.loads(raw_response)
+    except json.JSONDecodeError as exc:
+        raise BreakdownValidationError("Provider response must be valid JSON") from exc
+
+    try:
+        provider_breakdown = _ProviderBreakdown.model_validate(parsed)
+    except ValidationError as exc:
+        raise BreakdownValidationError("Provider response does not match the breakdown schema") from exc
+
+    return [
+        NormalizedBreakdownTask(
+            title=task.title,
+            description=task.description,
+            acceptance_criteria=task.acceptance_criteria,
+            position=position,
+            estimate_minutes=task.estimate_minutes,
+        )
+        for position, task in enumerate(provider_breakdown.tasks)
+    ]
+
+
+def _require_text(value: str, field_name: str) -> str:
+    stripped = value.strip()
+    if not stripped:
+        raise BreakdownValidationError(f"{field_name} is required")
+    return stripped

--- a/apps/api/app/schemas.py
+++ b/apps/api/app/schemas.py
@@ -107,6 +107,41 @@ class ProjectDetailRead(ProjectRead):
     tasks: list[TaskRead]
 
 
+class BreakdownRequest(BaseModel):
+    goal_text: str = Field(min_length=1)
+    project_id: int | None = None
+    provider: str = Field(default="mock", min_length=1, max_length=100)
+    model: str | None = Field(default=None, max_length=200)
+
+    @field_validator("goal_text", "provider")
+    @classmethod
+    def text_must_not_be_blank(cls, value: str, info: ValidationInfo) -> str:
+        return _require_text(value, info.field_name)
+
+    @field_validator("model")
+    @classmethod
+    def optional_text_must_not_be_blank(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _require_text(value, "model")
+
+
+class BreakdownTaskRead(BaseModel):
+    title: str
+    description: str | None
+    acceptance_criteria: str | None
+    position: int
+    estimate_minutes: int | None
+
+
+class BreakdownResponse(BaseModel):
+    provider: str
+    model: str
+    prompt_version: str
+    breakdown_run_id: int | None
+    tasks: list[BreakdownTaskRead]
+
+
 def _require_text(value: str, field_name: str) -> str:
     stripped = value.strip()
     if not stripped:

--- a/apps/api/tests/test_breakdowns.py
+++ b/apps/api/tests/test_breakdowns.py
@@ -1,0 +1,147 @@
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine
+
+from app.breakdowns import BreakdownValidationError, parse_provider_breakdown
+from app.database import create_db_and_tables, get_session
+from app.main import app
+from app.repositories import create_project, list_breakdown_runs
+
+
+@pytest.fixture
+def session() -> Iterator[Session]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    create_db_and_tables(engine)
+    with Session(engine) as session:
+        yield session
+    SQLModel.metadata.drop_all(engine)
+
+
+@pytest.fixture
+def client(session: Session) -> Iterator[TestClient]:
+    def override_get_session() -> Iterator[Session]:
+        yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+    with TestClient(app) as test_client:
+        yield test_client
+    app.dependency_overrides.clear()
+
+
+def test_mock_breakdown_endpoint_returns_validated_tasks(client: TestClient) -> None:
+    response = client.post(
+        "/api/breakdowns",
+        json={"goal_text": "Launch a small Koma Planner demo"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["provider"] == "mock"
+    assert body["model"] == "mock-breakdown-v1"
+    assert body["prompt_version"] == "breakdown-v1"
+    assert body["breakdown_run_id"] is None
+    assert [task["position"] for task in body["tasks"]] == [0, 1, 2, 3]
+    assert body["tasks"][0]["title"] == "Clarify the goal"
+    assert "Launch a small Koma Planner demo" in body["tasks"][0]["description"]
+
+
+def test_breakdown_request_validation_is_clear(client: TestClient) -> None:
+    response = client.post("/api/breakdowns", json={"goal_text": "   "})
+
+    assert response.status_code == 422
+    assert "goal_text" in str(response.json()["detail"])
+
+
+def test_breakdown_rejects_unavailable_provider(client: TestClient) -> None:
+    response = client.post(
+        "/api/breakdowns",
+        json={"goal_text": "Plan with a real provider later", "provider": "openai"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Only the mock provider is available"
+
+
+def test_breakdown_can_store_owner_scoped_metadata(
+    client: TestClient,
+    session: Session,
+) -> None:
+    project = create_project(
+        session,
+        owner_id="user-a",
+        title="Stored breakdown",
+        goal_text="Plan the saved project",
+    )
+    assert project.id is not None
+
+    response = client.post(
+        "/api/breakdowns",
+        headers={"X-Koma-Owner-Id": "user-a"},
+        json={"goal_text": project.goal_text, "project_id": project.id},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["breakdown_run_id"] is not None
+
+    runs = list_breakdown_runs(session, owner_id="user-a", project_id=project.id)
+    assert len(runs) == 1
+    assert runs[0].provider == "mock"
+    assert runs[0].model == "mock-breakdown-v1"
+    assert runs[0].prompt_version == "breakdown-v1"
+    assert runs[0].input_goal == project.goal_text
+    assert runs[0].raw_response is not None
+
+
+def test_breakdown_rejects_cross_owner_project(
+    client: TestClient,
+    session: Session,
+) -> None:
+    project = create_project(
+        session,
+        owner_id="user-a",
+        title="Private project",
+        goal_text="Protect this project",
+    )
+    assert project.id is not None
+
+    response = client.post(
+        "/api/breakdowns",
+        headers={"X-Koma-Owner-Id": "user-b"},
+        json={"goal_text": "Try to attach elsewhere", "project_id": project.id},
+    )
+
+    assert response.status_code == 404
+    assert list_breakdown_runs(session, owner_id="user-a", project_id=project.id) == []
+
+
+def test_parse_provider_breakdown_normalizes_task_positions() -> None:
+    tasks = parse_provider_breakdown(
+        '{"tasks":[{"title":" First task ","position":99},{"title":"Second task","estimate_minutes":15}]}'
+    )
+
+    assert [task.title for task in tasks] == ["First task", "Second task"]
+    assert [task.position for task in tasks] == [0, 1]
+    assert tasks[1].estimate_minutes == 15
+
+
+@pytest.mark.parametrize(
+    "raw_response",
+    [
+        "not json",
+        "{}",
+        '{"tasks":[]}',
+        '{"tasks":[{"title":"   "}]}',
+        '{"tasks":[{"title":"Valid","estimate_minutes":-1}]}',
+    ],
+)
+def test_parse_provider_breakdown_rejects_malformed_output(raw_response: str) -> None:
+    with pytest.raises(BreakdownValidationError):
+        parse_provider_breakdown(raw_response)

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,7 +5,8 @@
 ### Current Decision
 
 MVP 03 exposes the persisted project and task operations through FastAPI under
-the `/api` prefix.
+the `/api` prefix. MVP 04 adds the backend breakdown contract for turning a
+rough goal into validated task suggestions.
 
 Authentication is still deferred. Until authentication middleware exists, API
 requests are scoped by the `X-Koma-Owner-Id` header. If the header is omitted,
@@ -41,19 +42,43 @@ building the later auth service in this issue.
 - `DELETE /api/projects/{project_id}/tasks/{task_id}`
   - Deletes a task and its descendants.
 
+### Breakdown Endpoint
+
+- `POST /api/breakdowns`
+  - Accepts a rough `goal_text`.
+  - Returns normalized task suggestions with stable `position` values.
+  - Uses a local `mock` provider by default so development works without API
+    credits.
+  - Accepts optional `project_id`; when provided, a `BreakdownRun` metadata
+    record is stored for the owner-scoped project.
+
+Expected normalized task shape:
+
+```json
+{
+  "title": "Write a small API contract",
+  "description": "Optional details about the action",
+  "acceptance_criteria": "Optional completion check",
+  "position": 0,
+  "estimate_minutes": 30
+}
+```
+
 ### Validation
 
 Request bodies use typed schemas. Empty required text fields are rejected before
 data reaches the repository layer. Missing owner-scoped records return `404`.
 Invalid task reorder payloads return `400` because the task ID list must match
-the project's current task set exactly.
+the project's current task set exactly. Malformed breakdown provider output is
+rejected before tasks reach the frontend or database.
 
 ## Japanese
 
 ### 現在の決定
 
 MVP 03 では、永続化済みの project / task 操作を FastAPI の `/api` prefix
-配下で公開します。
+配下で公開します。MVP 04 では、rough goal を validated task suggestions に変換する
+backend breakdown contract を追加します。
 
 認証 middleware はまだ後続に回します。それまでの API request は
 `X-Koma-Owner-Id` header で owner scope を決めます。Header がない場合は、
@@ -89,9 +114,31 @@ model と揃えます。
 - `DELETE /api/projects/{project_id}/tasks/{task_id}`
   - Task とその descendants を削除します。
 
+### Breakdown Endpoint
+
+- `POST /api/breakdowns`
+  - Rough な `goal_text` を受け取ります。
+  - Stable な `position` を持つ normalized task suggestions を返します。
+  - Default では local `mock` provider を使うため、API credits なしで開発できます。
+  - 任意の `project_id` を受け取ります。指定された場合、owner-scoped project に
+    `BreakdownRun` metadata record を保存します。
+
+Expected normalized task shape:
+
+```json
+{
+  "title": "Write a small API contract",
+  "description": "Optional details about the action",
+  "acceptance_criteria": "Optional completion check",
+  "position": 0,
+  "estimate_minutes": 30
+}
+```
+
 ### Validation
 
 Request body は typed schema を使います。必須 text field が空の場合は、
 repository layer に届く前に reject します。Owner scope 内に record がない場合は
 `404` を返します。不正な task reorder payload は `400` を返します。Task ID list
-は project の現在の task set と完全に一致する必要があります。
+は project の現在の task set と完全に一致する必要があります。Malformed な
+breakdown provider output は、tasks が frontend や database に届く前に reject します。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,13 +67,25 @@ See `docs/api.md` for the current endpoint contract.
 ```text
 User goal
   -> frontend sends breakdown request
-  -> backend loads provider settings
-  -> backend calls AI provider
+  -> backend loads provider settings or local mock provider
+  -> backend calls AI provider or mock provider
   -> backend validates structured response
   -> backend returns normalized tasks
   -> frontend renders tasks as editable todos
   -> user saves project
 ```
+
+## MVP 04 Breakdown Direction
+
+The first breakdown implementation defines the provider output contract before
+adding paid provider calls. The backend expects JSON with a `tasks` array. Each
+task must have a non-empty `title` and may include `description`,
+`acceptance_criteria`, and `estimate_minutes`. The backend normalizes stable
+positions and rejects malformed provider output.
+
+The default provider is `mock`, which creates deterministic local task
+suggestions without an API key. This keeps the product flow testable before API
+key configuration is implemented.
 
 ## Early Deployment Assumption
 
@@ -145,13 +157,25 @@ deployment では、private project data を公開する前に real authenticati
 ```text
 User goal
   -> frontend sends breakdown request
-  -> backend loads provider settings
-  -> backend calls AI provider
+  -> backend loads provider settings or local mock provider
+  -> backend calls AI provider or mock provider
   -> backend validates structured response
   -> backend returns normalized tasks
   -> frontend renders tasks as editable todos
   -> user saves project
 ```
+
+### MVP 04 Breakdown 方針
+
+最初の breakdown 実装では、有料 provider call より先に provider output contract
+を定義します。Backend は `tasks` array を持つ JSON を期待します。各 task は
+空ではない `title` を必須とし、`description`、`acceptance_criteria`、
+`estimate_minutes` を任意で持てます。Backend は stable position を normalize し、
+malformed provider output を reject します。
+
+Default provider は `mock` です。API key なしで deterministic な local task
+suggestions を作ります。これにより、API key configuration の実装前でも product
+flow を test できます。
 
 ### 初期 deployment 方針
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -71,6 +71,13 @@ cd apps/api
 
 These same checks run in GitHub Actions for pull requests and pushes to `main`.
 
+### MVP 04 Test Rationale
+
+MVP 04 adds the breakdown contract before paid AI provider calls. Its backend
+tests should cover deterministic mock breakdown output, malformed provider
+output rejection, request validation, optional `BreakdownRun` metadata storage,
+and owner-scoped project checks when a breakdown is attached to a project.
+
 ### MVP 03 Test Rationale
 
 MVP 03 exposes the existing persistence layer through FastAPI. Its backend
@@ -179,6 +186,13 @@ cd apps/api
 ```
 
 同じ check は、pull request と `main` への push で GitHub Actions でも実行されます。
+
+### MVP 04 Test Rationale
+
+MVP 04 は有料 AI provider call より先に breakdown contract を追加します。Backend
+tests では、deterministic な mock breakdown output、malformed provider output の
+rejection、request validation、任意の `BreakdownRun` metadata storage、breakdown を
+project に紐づける場合の owner-scoped project checks を確認します。
 
 ### MVP 03 Test Rationale
 


### PR DESCRIPTION
## Summary

- Record the reusable issue implementation workflow under .agents/issue-workflow.md and link it from AGENTS.md.
- Document the MVP 04 breakdown contract, mock provider behavior, and validation expectations in English and Japanese.
- Add a typed POST /api/breakdowns endpoint with deterministic mock output, provider-output validation, optional BreakdownRun metadata storage, and focused backend tests.

Closes #4

## Validation

- npm run build:web
- npm run test:api with apps/api/.venv/Scripts first in PATH
- apps/api/.venv/Scripts/python.exe -m pytest -p no:cacheprovider tests