### PR TITLE
[MVP 06] Build goal input and breakdown workspace UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      - name: Run frontend tests
+        run: npm run test:web
+
       - name: Build frontend
         run: npm run build:web
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite --host 127.0.0.1",
     "build": "tsc -b && vite build",
+    "test": "node --experimental-strip-types tests/workspaceState.test.ts",
     "preview": "vite preview --host 127.0.0.1"
   },
   "dependencies": {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,32 +1,224 @@
 import { StrictMode } from "react";
+import { FormEvent, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
 import "./styles.css";
+import {
+  addTodo,
+  adoptBreakdownTasks,
+  applyBreakdownError,
+  initialWorkspaceState,
+  startBreakdownRequest,
+  toggleTodo,
+  updateTodoAcceptanceCriteria,
+  updateTodoDescription,
+  updateTodoTitle,
+  type BreakdownTask,
+  type WorkspaceState,
+} from "./workspaceState";
+
+type BreakdownResponse = {
+  provider: string;
+  model: string;
+  prompt_version: string;
+  breakdown_run_id: number | null;
+  tasks: BreakdownTask[];
+};
+
+const exampleGoals = [
+  "Launch a small portfolio site in two weeks",
+  "Prepare a first user interview for Koma Planner",
+  "Clean up my backlog before Friday",
+];
 
 function App() {
+  const [goalText, setGoalText] = useState("");
+  const [workspace, setWorkspace] = useState<WorkspaceState>(initialWorkspaceState);
+  const [formMessage, setFormMessage] = useState("");
+
+  const completedCount = useMemo(() => workspace.todos.filter((todo) => todo.completed).length, [workspace.todos]);
+  const canSubmit = goalText.trim().length > 0 && workspace.status !== "loading";
+
+  async function handleBreakdown(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmedGoal = goalText.trim();
+    if (!trimmedGoal) {
+      setFormMessage("Enter a goal before requesting a breakdown.");
+      return;
+    }
+
+    setFormMessage("");
+    const loadingState = startBreakdownRequest(trimmedGoal);
+    setWorkspace(loadingState);
+
+    try {
+      const response = await fetch("/api/breakdowns", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ goal_text: trimmedGoal }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Breakdown request failed with ${response.status}`);
+      }
+
+      const breakdown = (await response.json()) as BreakdownResponse;
+      setWorkspace(adoptBreakdownTasks(loadingState, breakdown.tasks));
+    } catch (error) {
+      setWorkspace(applyBreakdownError(loadingState, error));
+    }
+  }
+
+  function updateWorkspace(nextState: WorkspaceState) {
+    setWorkspace(nextState);
+  }
+
   return (
     <main className="app-shell">
-      <section className="workspace">
-        <div className="intro">
-          <p className="eyebrow">Koma Planner</p>
-          <h1>Turn a rough goal into todos you can start now.</h1>
-          <p>
-            This scaffold is ready for the MVP flow: goal input, AI breakdown,
-            editable tasks, and saved projects.
-          </p>
+      <header className="topbar" aria-label="Workspace header">
+        <div>
+          <p className="product-name">Koma Planner</p>
+          <h1>Goal breakdown workspace</h1>
         </div>
+        <div className="workspace-meter" aria-label="Todo progress">
+          <span>{completedCount}</span>
+          <span>/</span>
+          <span>{workspace.todos.length}</span>
+        </div>
+      </header>
 
-        <form className="goal-panel">
-          <label htmlFor="goal">Goal</label>
+      <section className="workspace">
+        <form className="goal-panel" onSubmit={handleBreakdown}>
+          <div className="panel-heading">
+            <label htmlFor="goal">Goal</label>
+            <span className="status-pill" data-status={workspace.status}>
+              {workspace.status === "idle" ? "Ready" : workspace.status}
+            </span>
+          </div>
           <textarea
             id="goal"
             name="goal"
-            rows={6}
+            rows={8}
+            value={goalText}
+            onChange={(event) => setGoalText(event.target.value)}
             placeholder="Example: Launch a small web app for AI-assisted todo breakdowns"
           />
-          <button type="button">Break down goal</button>
+          {formMessage ? <p className="form-message">{formMessage}</p> : null}
+          <div className="example-row" aria-label="Example goals">
+            {exampleGoals.map((goal) => (
+              <button key={goal} type="button" className="example-button" onClick={() => setGoalText(goal)}>
+                {goal}
+              </button>
+            ))}
+          </div>
+          <button className="primary-action" type="submit" disabled={!canSubmit}>
+            {workspace.status === "loading" ? "Breaking down..." : "Break down goal"}
+          </button>
         </form>
+
+        <section className="todo-workspace" aria-live="polite">
+          <div className="workspace-heading">
+            <div>
+              <p className="section-label">Todos</p>
+              <h2>{workspace.goalText || "Start with a rough goal"}</h2>
+            </div>
+            <button
+              type="button"
+              className="secondary-action"
+              onClick={() => updateWorkspace(addTodo(workspace))}
+              disabled={workspace.status === "loading"}
+            >
+              Add task
+            </button>
+          </div>
+
+          <WorkspaceStateView workspace={workspace} onWorkspaceChange={updateWorkspace} />
+        </section>
       </section>
     </main>
+  );
+}
+
+type WorkspaceStateViewProps = {
+  workspace: WorkspaceState;
+  onWorkspaceChange: (state: WorkspaceState) => void;
+};
+
+function WorkspaceStateView({ workspace, onWorkspaceChange }: WorkspaceStateViewProps) {
+  if (workspace.status === "loading") {
+    return (
+      <div className="state-panel" role="status">
+        <div className="loader" aria-hidden="true" />
+        <p>Creating a task breakdown...</p>
+      </div>
+    );
+  }
+
+  if (workspace.status === "error") {
+    return (
+      <div className="state-panel error-panel" role="alert">
+        <p>{workspace.errorMessage}</p>
+      </div>
+    );
+  }
+
+  if (workspace.status === "empty") {
+    return (
+      <div className="state-panel">
+        <p>No tasks came back for this goal. Try adding one manually or make the goal more specific.</p>
+      </div>
+    );
+  }
+
+  if (workspace.todos.length === 0) {
+    return (
+      <div className="state-panel">
+        <p>Your generated todos will appear here as soon as the breakdown is ready.</p>
+      </div>
+    );
+  }
+
+  return (
+    <ol className="todo-list">
+      {workspace.todos.map((todo) => (
+        <li key={todo.id} className="todo-item">
+          <label className="check-control">
+            <input
+              type="checkbox"
+              checked={todo.completed}
+              onChange={() => onWorkspaceChange(toggleTodo(workspace, todo.id))}
+            />
+            <span>{todo.completed ? "Done" : "Todo"}</span>
+          </label>
+          <div className="todo-fields">
+            <input
+              aria-label="Task title"
+              className="title-input"
+              value={todo.title}
+              onChange={(event) => onWorkspaceChange(updateTodoTitle(workspace, todo.id, event.target.value))}
+              placeholder="Task title"
+            />
+            <textarea
+              aria-label="Task description"
+              value={todo.description}
+              onChange={(event) => onWorkspaceChange(updateTodoDescription(workspace, todo.id, event.target.value))}
+              placeholder="Notes"
+              rows={2}
+            />
+            <textarea
+              aria-label="Acceptance criteria"
+              value={todo.acceptanceCriteria}
+              onChange={(event) =>
+                onWorkspaceChange(updateTodoAcceptanceCriteria(workspace, todo.id, event.target.value))
+              }
+              placeholder="Acceptance criteria"
+              rows={2}
+            />
+          </div>
+        </li>
+      ))}
+    </ol>
   );
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,6 +1,6 @@
 :root {
-  color: #17201a;
-  background: #f7f4ec;
+  color: #182129;
+  background: #f5f7f8;
   font-family:
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     sans-serif;
@@ -16,106 +16,345 @@ body {
 }
 
 button,
+input,
 textarea {
   font: inherit;
 }
 
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+
 .app-shell {
   min-height: 100vh;
-  padding: 48px 24px;
+  padding: 28px 24px 40px;
 }
 
+.topbar,
 .workspace {
-  display: grid;
-  grid-template-columns: minmax(0, 0.9fr) minmax(320px, 1.1fr);
-  gap: 40px;
-  width: min(1120px, 100%);
+  width: min(1180px, 100%);
   margin: 0 auto;
-  align-items: start;
 }
 
-.intro {
-  padding-top: 32px;
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: center;
+  padding: 0 0 24px;
 }
 
-.eyebrow {
-  margin: 0 0 16px;
-  color: #2d6a4f;
-  font-size: 0.85rem;
-  font-weight: 700;
+.product-name,
+.section-label {
+  margin: 0 0 6px;
+  color: #3c6e71;
+  font-size: 0.78rem;
+  font-weight: 800;
   letter-spacing: 0;
   text-transform: uppercase;
 }
 
-h1 {
-  margin: 0;
-  max-width: 680px;
-  font-size: clamp(2.25rem, 6vw, 4.75rem);
-  line-height: 0.98;
+h1,
+h2 {
   letter-spacing: 0;
 }
 
-.intro p:last-child {
-  max-width: 560px;
-  margin: 24px 0 0;
-  color: #4d574f;
-  font-size: 1.08rem;
-  line-height: 1.7;
+h1 {
+  margin: 0;
+  font-size: 2rem;
+  line-height: 1.08;
+}
+
+h2 {
+  margin: 0;
+  max-width: 680px;
+  font-size: 1.35rem;
+  line-height: 1.25;
+}
+
+.workspace-meter {
+  display: inline-grid;
+  grid-template-columns: auto auto auto;
+  align-items: center;
+  gap: 5px;
+  min-width: 86px;
+  min-height: 44px;
+  padding: 0 13px;
+  color: #ffffff;
+  background: #284b63;
+  border-radius: 8px;
+  font-weight: 800;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(300px, 0.82fr) minmax(0, 1.18fr);
+  gap: 24px;
+  align-items: start;
 }
 
 .goal-panel {
   display: grid;
   gap: 14px;
-  padding: 24px;
+  position: sticky;
+  top: 20px;
+  padding: 20px;
   background: #ffffff;
-  border: 1px solid #d8d1c1;
+  border: 1px solid #dce3e7;
   border-radius: 8px;
-  box-shadow: 0 24px 60px rgba(31, 36, 28, 0.08);
+  box-shadow: 0 18px 45px rgba(33, 44, 53, 0.08);
 }
 
-.goal-panel label {
-  font-weight: 700;
+.panel-heading,
+.workspace-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: start;
+}
+
+.panel-heading label {
+  font-size: 1.1rem;
+  font-weight: 800;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 10px;
+  color: #284b63;
+  background: #e9f0f3;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: capitalize;
+}
+
+.status-pill[data-status="loading"] {
+  color: #6d4b00;
+  background: #fff1c7;
+}
+
+.status-pill[data-status="success"] {
+  color: #215c40;
+  background: #dff4e9;
+}
+
+.status-pill[data-status="error"] {
+  color: #8b2635;
+  background: #ffe7eb;
 }
 
 .goal-panel textarea {
   width: 100%;
-  min-height: 220px;
+  min-height: 238px;
   resize: vertical;
-  color: #17201a;
-  background: #fbfaf6;
-  border: 1px solid #c8c0b0;
+  color: #182129;
+  background: #fbfcfd;
+  border: 1px solid #cbd6dc;
   border-radius: 6px;
   padding: 14px;
   line-height: 1.55;
 }
 
-.goal-panel button {
-  justify-self: end;
-  min-height: 44px;
-  padding: 0 18px;
-  color: #ffffff;
-  background: #2d6a4f;
-  border: 0;
-  border-radius: 6px;
+.goal-panel textarea:focus,
+.todo-fields input:focus,
+.todo-fields textarea:focus {
+  border-color: #3c6e71;
+  outline: 3px solid rgba(60, 110, 113, 0.16);
+}
+
+.form-message {
+  margin: -4px 0 0;
+  color: #8b2635;
   font-weight: 700;
-  cursor: pointer;
+}
+
+.example-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.example-button {
+  min-height: 34px;
+  padding: 0 10px;
+  color: #354550;
+  background: #eef3f5;
+  border: 1px solid #d8e0e4;
+  border-radius: 6px;
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.primary-action,
+.secondary-action {
+  min-height: 44px;
+  padding: 0 16px;
+  border-radius: 6px;
+  font-weight: 800;
+}
+
+.primary-action {
+  justify-self: stretch;
+  color: #ffffff;
+  background: #284b63;
+  border: 0;
+}
+
+.secondary-action {
+  color: #284b63;
+  background: #ffffff;
+  border: 1px solid #b8c7cf;
+  white-space: nowrap;
+}
+
+.todo-workspace {
+  min-width: 0;
+}
+
+.workspace-heading {
+  margin-bottom: 16px;
+}
+
+.todo-list {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.todo-item {
+  display: grid;
+  grid-template-columns: 88px minmax(0, 1fr);
+  gap: 14px;
+  padding: 16px;
+  background: #ffffff;
+  border: 1px solid #dce3e7;
+  border-radius: 8px;
+  box-shadow: 0 12px 28px rgba(33, 44, 53, 0.06);
+}
+
+.check-control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  align-self: start;
+  min-height: 38px;
+  color: #43515b;
+  font-weight: 800;
+}
+
+.check-control input {
+  width: 18px;
+  height: 18px;
+  accent-color: #3c6e71;
+}
+
+.todo-fields {
+  display: grid;
+  gap: 9px;
+  min-width: 0;
+}
+
+.todo-fields input,
+.todo-fields textarea {
+  width: 100%;
+  color: #182129;
+  background: #fbfcfd;
+  border: 1px solid #cbd6dc;
+  border-radius: 6px;
+  padding: 10px 11px;
+  line-height: 1.45;
+}
+
+.todo-fields textarea {
+  resize: vertical;
+}
+
+.title-input {
+  font-weight: 800;
+}
+
+.state-panel {
+  display: grid;
+  place-items: center;
+  min-height: 320px;
+  padding: 28px;
+  color: #43515b;
+  background: #ffffff;
+  border: 1px dashed #b8c7cf;
+  border-radius: 8px;
+  text-align: center;
+}
+
+.state-panel p {
+  max-width: 460px;
+  margin: 0;
+  line-height: 1.6;
+}
+
+.error-panel {
+  color: #8b2635;
+  border-color: #f2a7b3;
+  background: #fff8f9;
+  font-weight: 800;
+}
+
+.loader {
+  width: 34px;
+  height: 34px;
+  border: 4px solid #dce3e7;
+  border-top-color: #3c6e71;
+  border-radius: 50%;
+  animation: spin 0.9s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @media (max-width: 760px) {
   .app-shell {
-    padding: 28px 16px;
+    padding: 20px 14px 28px;
+  }
+
+  .topbar {
+    align-items: start;
+  }
+
+  h1 {
+    font-size: 1.65rem;
   }
 
   .workspace {
     grid-template-columns: 1fr;
-    gap: 24px;
-  }
-
-  .intro {
-    padding-top: 0;
+    gap: 20px;
   }
 
   .goal-panel {
-    padding: 18px;
+    position: static;
+  }
+
+  .workspace-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .todo-item {
+    grid-template-columns: 1fr;
+  }
+
+  .check-control {
+    min-height: 28px;
   }
 }

--- a/apps/web/src/workspaceState.ts
+++ b/apps/web/src/workspaceState.ts
@@ -1,0 +1,137 @@
+export type WorkspaceStatus = "idle" | "loading" | "empty" | "success" | "error";
+
+export type BreakdownTask = {
+  title: string;
+  description: string | null;
+  acceptance_criteria: string | null;
+  position: number;
+  estimate_minutes: number | null;
+};
+
+export type TodoItem = {
+  id: string;
+  title: string;
+  description: string;
+  acceptanceCriteria: string;
+  estimateMinutes: number | null;
+  completed: boolean;
+  position: number;
+};
+
+export type WorkspaceState = {
+  status: WorkspaceStatus;
+  goalText: string;
+  todos: TodoItem[];
+  errorMessage: string;
+};
+
+export const initialWorkspaceState: WorkspaceState = {
+  status: "idle",
+  goalText: "",
+  todos: [],
+  errorMessage: "",
+};
+
+const friendlyBreakdownError = "We could not break down that goal. Please adjust the goal and try again.";
+
+export function startBreakdownRequest(goalText: string): WorkspaceState {
+  return {
+    status: "loading",
+    goalText: goalText.trim(),
+    todos: [],
+    errorMessage: "",
+  };
+}
+
+export function adoptBreakdownTasks(state: WorkspaceState, tasks: BreakdownTask[]): WorkspaceState {
+  const todos = tasks
+    .slice()
+    .sort((left, right) => left.position - right.position)
+    .map((task, index) => createTodo(task, index));
+
+  return {
+    ...state,
+    status: todos.length > 0 ? "success" : "empty",
+    todos,
+    errorMessage: "",
+  };
+}
+
+export function applyBreakdownError(state: WorkspaceState, _error: unknown): WorkspaceState {
+  return {
+    ...state,
+    status: "error",
+    errorMessage: friendlyBreakdownError,
+  };
+}
+
+export function addTodo(state: WorkspaceState): WorkspaceState {
+  const position = state.todos.length;
+  return {
+    ...state,
+    status: "success",
+    todos: [
+      ...state.todos,
+      {
+        id: `local-${Date.now()}-${position}`,
+        title: "",
+        description: "",
+        acceptanceCriteria: "",
+        estimateMinutes: null,
+        completed: false,
+        position,
+      },
+    ],
+  };
+}
+
+export function updateTodoTitle(state: WorkspaceState, todoId: string, title: string): WorkspaceState {
+  return updateTodo(state, todoId, (todo) => ({ ...todo, title }));
+}
+
+export function updateTodoDescription(state: WorkspaceState, todoId: string, description: string): WorkspaceState {
+  return updateTodo(state, todoId, (todo) => ({ ...todo, description }));
+}
+
+export function updateTodoAcceptanceCriteria(
+  state: WorkspaceState,
+  todoId: string,
+  acceptanceCriteria: string,
+): WorkspaceState {
+  return updateTodo(state, todoId, (todo) => ({ ...todo, acceptanceCriteria }));
+}
+
+export function toggleTodo(state: WorkspaceState, todoId: string): WorkspaceState {
+  return updateTodo(state, todoId, (todo) => ({ ...todo, completed: !todo.completed }));
+}
+
+export function deleteTodo(state: WorkspaceState, todoId: string): WorkspaceState {
+  const todos = state.todos
+    .filter((todo) => todo.id !== todoId)
+    .map((todo, position) => ({ ...todo, position }));
+
+  return {
+    ...state,
+    status: todos.length > 0 ? state.status : "empty",
+    todos,
+  };
+}
+
+function updateTodo(state: WorkspaceState, todoId: string, update: (todo: TodoItem) => TodoItem): WorkspaceState {
+  return {
+    ...state,
+    todos: state.todos.map((todo) => (todo.id === todoId ? update(todo) : todo)),
+  };
+}
+
+function createTodo(task: BreakdownTask, index: number): TodoItem {
+  return {
+    id: `generated-${task.position}-${index}`,
+    title: task.title,
+    description: task.description ?? "",
+    acceptanceCriteria: task.acceptance_criteria ?? "",
+    estimateMinutes: task.estimate_minutes,
+    completed: false,
+    position: index,
+  };
+}

--- a/apps/web/tests/workspaceState.test.ts
+++ b/apps/web/tests/workspaceState.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import {
+  addTodo,
+  adoptBreakdownTasks,
+  applyBreakdownError,
+  deleteTodo,
+  startBreakdownRequest,
+  toggleTodo,
+  updateTodoTitle,
+  type WorkspaceState,
+} from "../src/workspaceState.ts";
+
+const state = startBreakdownRequest("  Launch a small workshop  ");
+
+assert.equal(state.status, "loading");
+assert.equal(state.goalText, "Launch a small workshop");
+assert.deepEqual(state.todos, []);
+assert.equal(state.errorMessage, "");
+
+const loading = startBreakdownRequest("Build a release checklist");
+const success = adoptBreakdownTasks(loading, [
+  {
+    title: "List release blockers",
+    description: "Check bugs, docs, and deployment risks",
+    acceptance_criteria: "Each blocker has an owner",
+    position: 0,
+    estimate_minutes: 20,
+  },
+  {
+    title: "Ship the release",
+    description: null,
+    acceptance_criteria: null,
+    position: 1,
+    estimate_minutes: null,
+  },
+]);
+
+assert.equal(success.status, "success");
+assert.equal(success.todos.length, 2);
+assert.equal(success.todos[0]?.title, "List release blockers");
+assert.equal(success.todos[0]?.completed, false);
+assert.equal(success.todos[0]?.acceptanceCriteria, "Each blocker has an owner");
+assert.equal(success.todos[1]?.description, "");
+
+const empty = adoptBreakdownTasks(startBreakdownRequest("Plan"), []);
+
+assert.equal(empty.status, "empty");
+assert.deepEqual(empty.todos, []);
+
+const errorState = applyBreakdownError(startBreakdownRequest("Plan"), new Error("stack trace and backend internals"));
+
+assert.equal(errorState.status, "error");
+assert.equal(errorState.errorMessage, "We could not break down that goal. Please adjust the goal and try again.");
+
+const initial: WorkspaceState = adoptBreakdownTasks(startBreakdownRequest("Plan"), [
+  {
+    title: "Draft plan",
+    description: null,
+    acceptance_criteria: null,
+    position: 0,
+    estimate_minutes: null,
+  },
+]);
+
+const added = addTodo(initial);
+const renamed = updateTodoTitle(added, added.todos[1]!.id, "Ask for feedback");
+const toggled = toggleTodo(renamed, renamed.todos[0]!.id);
+const deleted = deleteTodo(toggled, toggled.todos[0]!.id);
+
+assert.equal(added.todos.length, 2);
+assert.equal(renamed.todos[1]?.title, "Ask for feedback");
+assert.equal(toggled.todos[0]?.completed, true);
+assert.equal(deleted.todos.length, 1);
+assert.equal(deleted.todos[0]?.title, "Ask for feedback");

--- a/docs/api.md
+++ b/docs/api.md
@@ -51,6 +51,8 @@ building the later auth service in this issue.
     credits.
   - Accepts optional `project_id`; when provided, a `BreakdownRun` metadata
     record is stored for the owner-scoped project.
+  - MVP 06 frontend calls this endpoint without `project_id` for an unsaved
+    workspace, then renders the returned suggestions as editable local todos.
 
 Expected normalized task shape:
 
@@ -122,6 +124,8 @@ model と揃えます。
   - Default では local `mock` provider を使うため、API credits なしで開発できます。
   - 任意の `project_id` を受け取ります。指定された場合、owner-scoped project に
     `BreakdownRun` metadata record を保存します。
+  - MVP 06 frontend は、保存前 workspace では `project_id` なしでこの endpoint を
+    呼び出し、返された suggestions を editable な local todo として表示します。
 
 Expected normalized task shape:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,6 +87,18 @@ The default provider is `mock`, which creates deterministic local task
 suggestions without an API key. This keeps the product flow testable before API
 key configuration is implemented.
 
+## MVP 06 Workspace Direction
+
+The first frontend breakdown workspace consumes the existing
+`POST /api/breakdowns` mock endpoint directly from the initial screen. A
+submitted goal creates an unsaved workspace state: loading, success, empty, and
+error states stay visible in the same work surface, and generated suggestions
+are converted into editable local todos immediately.
+
+MVP 06 does not persist the generated list automatically. Saving the project,
+reopening saved projects, and attaching breakdown runs to persisted projects
+remain later frontend work against the existing project/task API.
+
 ## Early Deployment Assumption
 
 The first version can run locally, but persisted data should still be scoped as private user data. Any network-accessible deployment should require login. Authentication will be implemented later in a separate self-hosted service, while Koma Planner keeps owner-scoped project records.
@@ -176,6 +188,18 @@ malformed provider output を reject します。
 Default provider は `mock` です。API key なしで deterministic な local task
 suggestions を作ります。これにより、API key configuration の実装前でも product
 flow を test できます。
+
+### MVP 06 Workspace 方針
+
+最初の frontend breakdown workspace は、初期画面から既存の
+`POST /api/breakdowns` mock endpoint を直接呼び出します。Goal を送信すると、
+保存前の workspace state が作られます。Loading、success、empty、error states は
+同じ作業面の中で表示し、生成された suggestions はすぐ editable な local todo に
+変換します。
+
+MVP 06 では generated list を自動保存しません。Project の保存、保存済み project
+の再オープン、persisted project に紐づく breakdown run の記録は、既存の
+project/task API を使う後続の frontend work とします。
 
 ### 初期 deployment 方針
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -56,6 +56,12 @@ Frontend build and type check:
 npm run build:web
 ```
 
+Frontend state tests:
+
+```powershell
+npm run test:web
+```
+
 Backend tests, after activating `apps/api/.venv`:
 
 ```powershell
@@ -77,6 +83,15 @@ MVP 04 adds the breakdown contract before paid AI provider calls. Its backend
 tests should cover deterministic mock breakdown output, malformed provider
 output rejection, request validation, optional `BreakdownRun` metadata storage,
 and owner-scoped project checks when a breakdown is attached to a project.
+
+### MVP 06 Test Rationale
+
+MVP 06 connects the initial workspace UI to the existing breakdown endpoint.
+Frontend tests should cover the local workspace state transitions that are
+independent of browser rendering: request start, successful task adoption,
+empty breakdown results, understandable error state, and todo edits after
+generation. `npm run build:web` remains the rendering and TypeScript integration
+check.
 
 ### MVP 03 Test Rationale
 
@@ -172,6 +187,12 @@ Frontend build and type check:
 npm run build:web
 ```
 
+Frontend state tests:
+
+```powershell
+npm run test:web
+```
+
 Backend tests は、`apps/api/.venv` を有効化した後に実行します。
 
 ```powershell
@@ -193,6 +214,15 @@ MVP 04 は有料 AI provider call より先に breakdown contract を追加し�
 tests では、deterministic な mock breakdown output、malformed provider output の
 rejection、request validation、任意の `BreakdownRun` metadata storage、breakdown を
 project に紐づける場合の owner-scoped project checks を確認します。
+
+### MVP 06 Test Rationale
+
+MVP 06 は initial workspace UI を既存の breakdown endpoint に接続します。
+Frontend tests では、browser rendering に依存しない local workspace state
+transitions を確認します。具体的には request start、successful task adoption、
+empty breakdown results、understandable error state、generation 後の todo edit を
+対象にします。`npm run build:web` は引き続き rendering と TypeScript integration
+の check として使います。
 
 ### MVP 03 Test Rationale
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev:web": "npm --prefix apps/web run dev",
     "build:web": "npm --prefix apps/web run build",
+    "test:web": "npm --prefix apps/web run test",
     "preview:web": "npm --prefix apps/web run preview",
     "dev:api": "python -m uvicorn app.main:app --reload --app-dir apps/api",
     "test:api": "cd apps/api && python -m pytest -p no:cacheprovider tests"


### PR DESCRIPTION
## Summary

- Connect the initial React workspace to `POST /api/breakdowns` and render returned suggestions as editable local todos.
- Add loading, empty, success, and friendly error states for the breakdown flow.
- Add frontend workspace state tests, include them in CI, and document the MVP 06 workspace/test decisions in English and Japanese.

Closes #6

## Validation

- `npm run test:web`
- `npm run build:web`
- `apps/api/.venv/Scripts/python.exe -m pytest -p no:cacheprovider tests`
- Manual Playwright smoke against local FastAPI + Vite dev server: desktop and narrow viewports generated 4 todos, no desktop item overlap, and no narrow horizontal overflow.
